### PR TITLE
Enhance todo schema with links and categories

### DIFF
--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -2,7 +2,10 @@ use axum::{
     extract::{Json, Path},
     http::StatusCode,
 };
-use shared_types::{CreateTodoRequest, Todo, UpdateTodoRequest};
+use shared_types::{
+    Category, CreateCategoryRequest, CreateTodoRequest, Todo, UpdateCategoryRequest,
+    UpdateTodoRequest,
+};
 use uuid::Uuid;
 
 pub async fn list_todos() -> Result<Json<Vec<Todo>>, StatusCode> {
@@ -23,5 +26,27 @@ pub async fn update_todo(
 }
 
 pub async fn delete_todo(Path(_id): Path<Uuid>) -> Result<StatusCode, StatusCode> {
+    Err(StatusCode::NOT_IMPLEMENTED)
+}
+
+// Category handlers
+pub async fn list_categories() -> Result<Json<Vec<Category>>, StatusCode> {
+    Ok(Json(vec![]))
+}
+
+pub async fn create_category(
+    Json(_payload): Json<CreateCategoryRequest>,
+) -> Result<Json<Category>, StatusCode> {
+    Err(StatusCode::NOT_IMPLEMENTED)
+}
+
+pub async fn update_category(
+    Path(_id): Path<Uuid>,
+    Json(_payload): Json<UpdateCategoryRequest>,
+) -> Result<Json<Category>, StatusCode> {
+    Err(StatusCode::NOT_IMPLEMENTED)
+}
+
+pub async fn delete_category(Path(_id): Path<Uuid>) -> Result<StatusCode, StatusCode> {
     Err(StatusCode::NOT_IMPLEMENTED)
 }

--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -21,6 +21,10 @@ async fn main() -> anyhow::Result<()> {
         .route("/api/todos", post(handlers::create_todo))
         .route("/api/todos/:id", put(handlers::update_todo))
         .route("/api/todos/:id", delete(handlers::delete_todo))
+        .route("/api/categories", get(handlers::list_categories))
+        .route("/api/categories", post(handlers::create_category))
+        .route("/api/categories/:id", put(handlers::update_category))
+        .route("/api/categories/:id", delete(handlers::delete_category))
         .layer(CorsLayer::permissive());
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 3000));

--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -1,17 +1,35 @@
-use shared_types::Todo;
+use shared_types::{Category, Todo};
 use yew::prelude::*;
 
 #[function_component(App)]
 fn app() -> Html {
     let todos = use_state(Vec::<Todo>::new);
+    let categories = use_state(Vec::<Category>::new);
+    let show_categories = use_state(|| false);
+
+    let toggle_categories = {
+        let show_categories = show_categories.clone();
+        Callback::from(move |_| {
+            show_categories.set(!*show_categories);
+        })
+    };
 
     html! {
         <div class="app">
             <header>
                 <h1>{"Agentive Inversion - Self-Updating Todo List"}</h1>
+                <nav>
+                    <button onclick={toggle_categories}>
+                        {if *show_categories { "Hide Categories" } else { "Manage Categories" }}
+                    </button>
+                </nav>
             </header>
             <main>
-                <TodoList todos={(*todos).clone()} />
+                {if *show_categories {
+                    html! { <CategoryManager categories={(*categories).clone()} /> }
+                } else {
+                    html! { <TodoList todos={(*todos).clone()} categories={(*categories).clone()} /> }
+                }}
             </main>
         </div>
     }
@@ -20,23 +38,70 @@ fn app() -> Html {
 #[derive(Properties, PartialEq)]
 struct TodoListProps {
     todos: Vec<Todo>,
+    categories: Vec<Category>,
 }
 
 #[function_component(TodoList)]
 fn todo_list(props: &TodoListProps) -> Html {
+    // Sort todos by due date (nulls last)
+    let mut sorted_todos = props.todos.clone();
+    sorted_todos.sort_by(|a, b| match (&a.due_date, &b.due_date) {
+        (Some(date_a), Some(date_b)) => date_a.cmp(date_b),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    });
+
     html! {
         <div class="todo-list">
             {
-                if props.todos.is_empty() {
+                if sorted_todos.is_empty() {
                     html! { <p>{"No todos yet!"}</p> }
                 } else {
-                    props.todos.iter().map(|todo| {
+                    sorted_todos.iter().map(|todo| {
+                        let category = todo.category_id
+                            .and_then(|cat_id| props.categories.iter().find(|c| c.id == cat_id));
+
                         html! {
                             <div key={todo.id.to_string()} class="todo-item">
                                 <h3>{&todo.title}</h3>
                                 {
                                     if let Some(desc) = &todo.description {
-                                        html! { <p>{desc}</p> }
+                                        html! { <p class="description">{desc}</p> }
+                                    } else {
+                                        html! {}
+                                    }
+                                }
+                                {
+                                    if let Some(due) = &todo.due_date {
+                                        html! {
+                                            <p class="due-date">
+                                                {"Due: "}
+                                                {due.format("%Y-%m-%d %H:%M").to_string()}
+                                            </p>
+                                        }
+                                    } else {
+                                        html! {}
+                                    }
+                                }
+                                {
+                                    if let Some(link) = &todo.link {
+                                        html! {
+                                            <p class="link">
+                                                <a href={link.clone()} target="_blank">{"View Link"}</a>
+                                            </p>
+                                        }
+                                    } else {
+                                        html! {}
+                                    }
+                                }
+                                {
+                                    if let Some(cat) = category {
+                                        html! {
+                                            <span class="category" style={format!("background-color: {}", cat.color.as_deref().unwrap_or("#cccccc"))}>
+                                                {&cat.name}
+                                            </span>
+                                        }
                                     } else {
                                         html! {}
                                     }
@@ -46,6 +111,48 @@ fn todo_list(props: &TodoListProps) -> Html {
                     }).collect::<Html>()
                 }
             }
+        </div>
+    }
+}
+
+#[derive(Properties, PartialEq)]
+struct CategoryManagerProps {
+    categories: Vec<Category>,
+}
+
+#[function_component(CategoryManager)]
+fn category_manager(props: &CategoryManagerProps) -> Html {
+    html! {
+        <div class="category-manager">
+            <h2>{"Manage Categories"}</h2>
+            <div class="category-list">
+                {
+                    if props.categories.is_empty() {
+                        html! { <p>{"No categories yet!"}</p> }
+                    } else {
+                        props.categories.iter().map(|category| {
+                            html! {
+                                <div key={category.id.to_string()} class="category-item">
+                                    <div
+                                        class="category-color"
+                                        style={format!("background-color: {}", category.color.as_deref().unwrap_or("#cccccc"))}
+                                    />
+                                    <span class="category-name">{&category.name}</span>
+                                    <button class="delete-btn">{"Delete"}</button>
+                                </div>
+                            }
+                        }).collect::<Html>()
+                    }
+                }
+            </div>
+            <div class="add-category">
+                <h3>{"Add New Category"}</h3>
+                <form>
+                    <input type="text" placeholder="Category name" />
+                    <input type="color" />
+                    <button type="submit">{"Add Category"}</button>
+                </form>
+            </div>
         </div>
     }
 }

--- a/crates/shared-types/src/lib.rs
+++ b/crates/shared-types/src/lib.rs
@@ -12,6 +12,8 @@ pub struct Todo {
     pub source: TodoSource,
     pub source_id: Option<String>,
     pub due_date: Option<DateTime<Utc>>,
+    pub link: Option<String>,
+    pub category_id: Option<Uuid>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -30,6 +32,8 @@ pub struct CreateTodoRequest {
     pub title: String,
     pub description: Option<String>,
     pub due_date: Option<DateTime<Utc>>,
+    pub link: Option<String>,
+    pub category_id: Option<Uuid>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -38,6 +42,8 @@ pub struct UpdateTodoRequest {
     pub description: Option<String>,
     pub completed: Option<bool>,
     pub due_date: Option<DateTime<Utc>>,
+    pub link: Option<String>,
+    pub category_id: Option<Uuid>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -62,4 +68,26 @@ pub struct CalendarAccount {
     pub calendar_id: String,
     pub last_synced: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "diesel", derive(diesel::Queryable))]
+pub struct Category {
+    pub id: Uuid,
+    pub name: String,
+    pub color: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateCategoryRequest {
+    pub name: String,
+    pub color: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateCategoryRequest {
+    pub name: Option<String>,
+    pub color: Option<String>,
 }

--- a/migrations/2024-01-02-000001_add_todo_enhancements/down.sql
+++ b/migrations/2024-01-02-000001_add_todo_enhancements/down.sql
@@ -1,0 +1,6 @@
+-- Remove the category_id and link columns from todos
+ALTER TABLE todos DROP COLUMN category_id;
+ALTER TABLE todos DROP COLUMN link;
+
+-- Drop the categories table
+DROP TABLE categories;

--- a/migrations/2024-01-02-000001_add_todo_enhancements/up.sql
+++ b/migrations/2024-01-02-000001_add_todo_enhancements/up.sql
@@ -1,0 +1,22 @@
+-- Create categories table
+CREATE TABLE categories (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR NOT NULL UNIQUE,
+    color VARCHAR,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Add link and category_id columns to todos table
+ALTER TABLE todos ADD COLUMN link VARCHAR;
+ALTER TABLE todos ADD COLUMN category_id UUID REFERENCES categories(id) ON DELETE SET NULL;
+
+-- Add index for category lookups
+CREATE INDEX idx_todos_category_id ON todos(category_id);
+
+-- Add some default categories
+INSERT INTO categories (name, color) VALUES
+    ('Work', '#3b82f6'),
+    ('Personal', '#10b981'),
+    ('Important', '#ef4444'),
+    ('Later', '#8b5cf6');


### PR DESCRIPTION
- Add link field to todos for attaching URLs
- Add category support with configurable categories table
- Add category_id foreign key to todos
- Create default categories (Work, Personal, Important, Later)
- Implement due date sorting in frontend (nulls last)
- Add category management UI with toggle button
- Display category badges with custom colors in todo items
- Add API endpoints for category CRUD operations
- Create database migration for new schema changes