### PR TITLE
Migrate email-poller from IMAP to Gmail API OAuth

### DIFF
--- a/crates/email-poller/src/gmail_client.rs
+++ b/crates/email-poller/src/gmail_client.rs
@@ -38,7 +38,7 @@ impl GmailClient {
 
         let auth = google_gmail1::yup_oauth2::InstalledFlowAuthenticator::builder(
             secret,
-            google_gmail1::yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+            google_gmail1::yup_oauth2::InstalledFlowReturnMethod::Interactive,
         )
         .persist_tokens_to_disk(Path::new(&config.token_cache_path))
         .build()

--- a/crates/email-poller/src/main.rs
+++ b/crates/email-poller/src/main.rs
@@ -23,6 +23,11 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install rustls crypto provider
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     tracing_subscriber::fmt::init();
     dotenvy::dotenv().ok();
 


### PR DESCRIPTION
## Summary
- Replace IMAP-based email polling with Gmail API using OAuth2 authentication
- Use interactive OAuth flow for better CLI/headless support
- Add rustls crypto provider initialization
- Simplify configuration by removing IMAP-specific settings

## Test plan
- [ ] Run `cargo run --bin email-poller` and verify OAuth flow completes
- [ ] Confirm emails are fetched via Gmail API
- [ ] Verify token caching works for subsequent runs