### PR TITLE
Add email inbox view to frontend

### DIFF
--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -1,36 +1,174 @@
-use shared_types::{Category, Todo};
+use gloo_net::http::Request;
+use shared_types::{Category, EmailResponse, Todo};
 use yew::prelude::*;
+
+#[derive(Clone, PartialEq)]
+enum View {
+    Inbox,
+    Todos,
+    Categories,
+}
 
 #[function_component(App)]
 fn app() -> Html {
     let todos = use_state(Vec::<Todo>::new);
     let categories = use_state(Vec::<Category>::new);
-    let show_categories = use_state(|| false);
+    let current_view = use_state(|| View::Inbox);
 
-    let toggle_categories = {
-        let show_categories = show_categories.clone();
-        Callback::from(move |_| {
-            show_categories.set(!*show_categories);
-        })
+    let set_view_inbox = {
+        let current_view = current_view.clone();
+        Callback::from(move |_| current_view.set(View::Inbox))
+    };
+
+    let set_view_todos = {
+        let current_view = current_view.clone();
+        Callback::from(move |_| current_view.set(View::Todos))
+    };
+
+    let set_view_categories = {
+        let current_view = current_view.clone();
+        Callback::from(move |_| current_view.set(View::Categories))
     };
 
     html! {
         <div class="app">
             <header>
-                <h1>{"Agentive Inversion - Self-Updating Todo List"}</h1>
-                <nav>
-                    <button onclick={toggle_categories}>
-                        {if *show_categories { "Hide Categories" } else { "Manage Categories" }}
+                <h1>{"Agentive Inversion"}</h1>
+                <nav class="main-nav">
+                    <button
+                        class={if *current_view == View::Inbox { "nav-btn active" } else { "nav-btn" }}
+                        onclick={set_view_inbox}
+                    >
+                        {"Inbox"}
+                    </button>
+                    <button
+                        class={if *current_view == View::Todos { "nav-btn active" } else { "nav-btn" }}
+                        onclick={set_view_todos}
+                    >
+                        {"Todos"}
+                    </button>
+                    <button
+                        class={if *current_view == View::Categories { "nav-btn active" } else { "nav-btn" }}
+                        onclick={set_view_categories}
+                    >
+                        {"Categories"}
                     </button>
                 </nav>
             </header>
             <main>
-                {if *show_categories {
-                    html! { <CategoryManager categories={(*categories).clone()} /> }
-                } else {
-                    html! { <TodoList todos={(*todos).clone()} categories={(*categories).clone()} /> }
+                {match &*current_view {
+                    View::Inbox => html! { <EmailInbox /> },
+                    View::Todos => html! { <TodoList todos={(*todos).clone()} categories={(*categories).clone()} /> },
+                    View::Categories => html! { <CategoryManager categories={(*categories).clone()} /> },
                 }}
             </main>
+        </div>
+    }
+}
+
+#[function_component(EmailInbox)]
+fn email_inbox() -> Html {
+    let emails = use_state(Vec::<EmailResponse>::new);
+    let loading = use_state(|| true);
+    let error = use_state(|| None::<String>);
+
+    {
+        let emails = emails.clone();
+        let loading = loading.clone();
+        let error = error.clone();
+
+        use_effect_with((), move |_| {
+            wasm_bindgen_futures::spawn_local(async move {
+                match Request::get("/api/emails?limit=50").send().await {
+                    Ok(response) => {
+                        if response.ok() {
+                            match response.json::<Vec<EmailResponse>>().await {
+                                Ok(data) => {
+                                    emails.set(data);
+                                    loading.set(false);
+                                }
+                                Err(e) => {
+                                    error.set(Some(format!("Failed to parse emails: {}", e)));
+                                    loading.set(false);
+                                }
+                            }
+                        } else {
+                            error.set(Some(format!("API error: {}", response.status())));
+                            loading.set(false);
+                        }
+                    }
+                    Err(e) => {
+                        error.set(Some(format!("Network error: {}", e)));
+                        loading.set(false);
+                    }
+                }
+            });
+            || ()
+        });
+    }
+
+    if *loading {
+        return html! {
+            <div class="email-inbox">
+                <h2>{"Inbox"}</h2>
+                <p class="loading">{"Loading emails..."}</p>
+            </div>
+        };
+    }
+
+    if let Some(err) = &*error {
+        return html! {
+            <div class="email-inbox">
+                <h2>{"Inbox"}</h2>
+                <p class="error">{err}</p>
+            </div>
+        };
+    }
+
+    let emails_list = (*emails).clone();
+
+    html! {
+        <div class="email-inbox">
+            <h2>{"Inbox"}</h2>
+            <p class="email-count">{format!("{} emails", emails_list.len())}</p>
+            <div class="email-list">
+                {if emails_list.is_empty() {
+                    html! { <p class="empty-state">{"No emails found. Connect an email account to get started."}</p> }
+                } else {
+                    emails_list.iter().map(|email| {
+                        let from_display = email.from_name.clone()
+                            .unwrap_or_else(|| email.from_address.clone());
+                        let received = email.received_at.format("%b %d, %H:%M").to_string();
+
+                        html! {
+                            <div key={email.id.to_string()} class={format!("email-item {}", if email.processed { "processed" } else { "" })}>
+                                <div class="email-header">
+                                    <span class="email-from">{from_display}</span>
+                                    <span class="email-date">{received}</span>
+                                </div>
+                                <div class="email-subject">{&email.subject}</div>
+                                {if let Some(snippet) = &email.snippet {
+                                    html! { <div class="email-snippet">{snippet}</div> }
+                                } else {
+                                    html! {}
+                                }}
+                                <div class="email-badges">
+                                    {if email.has_attachments {
+                                        html! { <span class="badge attachment">{"Attachment"}</span> }
+                                    } else {
+                                        html! {}
+                                    }}
+                                    {if email.processed {
+                                        html! { <span class="badge processed">{"Processed"}</span> }
+                                    } else {
+                                        html! { <span class="badge pending">{"Pending"}</span> }
+                                    }}
+                                </div>
+                            </div>
+                        }
+                    }).collect::<Html>()
+                }}
+            </div>
         </div>
     }
 }

--- a/crates/frontend/styles.css
+++ b/crates/frontend/styles.css
@@ -64,3 +64,135 @@ main {
     color: #7f8c8d;
     font-size: 14px;
 }
+
+/* Navigation styles */
+.main-nav {
+    display: flex;
+    gap: 8px;
+    margin-top: 16px;
+}
+
+.nav-btn {
+    padding: 8px 16px;
+    border: 1px solid #3498db;
+    background-color: white;
+    color: #3498db;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: all 0.2s;
+}
+
+.nav-btn:hover {
+    background-color: #ecf0f1;
+}
+
+.nav-btn.active {
+    background-color: #3498db;
+    color: white;
+}
+
+/* Email inbox styles */
+.email-inbox h2 {
+    margin-bottom: 8px;
+    color: #2c3e50;
+}
+
+.email-count {
+    color: #7f8c8d;
+    font-size: 14px;
+    margin-bottom: 16px;
+}
+
+.email-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.email-item {
+    padding: 16px;
+    background-color: #f9f9f9;
+    border-left: 4px solid #e74c3c;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.email-item:hover {
+    background-color: #f0f0f0;
+    transform: translateX(2px);
+}
+
+.email-item.processed {
+    border-left-color: #27ae60;
+    opacity: 0.8;
+}
+
+.email-header {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 4px;
+}
+
+.email-from {
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.email-date {
+    font-size: 12px;
+    color: #95a5a6;
+}
+
+.email-subject {
+    font-size: 15px;
+    color: #34495e;
+    margin-bottom: 4px;
+}
+
+.email-snippet {
+    font-size: 13px;
+    color: #7f8c8d;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-bottom: 8px;
+}
+
+.email-badges {
+    display: flex;
+    gap: 8px;
+}
+
+.badge {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 12px;
+    text-transform: uppercase;
+}
+
+.badge.pending {
+    background-color: #f39c12;
+    color: white;
+}
+
+.badge.processed {
+    background-color: #27ae60;
+    color: white;
+}
+
+.badge.attachment {
+    background-color: #9b59b6;
+    color: white;
+}
+
+.loading, .error, .empty-state {
+    padding: 40px;
+    text-align: center;
+    color: #7f8c8d;
+}
+
+.error {
+    color: #e74c3c;
+}


### PR DESCRIPTION
## Summary
- Add navigation tabs (Inbox, Todos, Categories) to switch between views
- Create EmailInbox component that fetches and displays emails from /api/emails
- Show email sender, subject, snippet, and status badges (pending/processed/attachment)
- Style inbox items with visual indicators for processed vs unprocessed emails

## Test plan
- [ ] Run `trunk serve` in frontend and verify inbox view loads
- [ ] Verify navigation between Inbox/Todos/Categories works
- [ ] Check that emails are fetched from the API and displayed
- [ ] Verify styling matches the design (unprocessed = red border, processed = green border)