### PR TITLE
Wire up Todos view with API integration

### DIFF
--- a/crates/frontend/styles.css
+++ b/crates/frontend/styles.css
@@ -196,3 +196,183 @@ main {
 .error {
     color: #e74c3c;
 }
+
+/* Todo container styles */
+.todo-container h2 {
+    margin-bottom: 16px;
+    color: #2c3e50;
+}
+
+.todo-form {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.todo-form input {
+    flex: 1;
+    padding: 10px 12px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+.todo-form input:focus {
+    outline: none;
+    border-color: #3498db;
+}
+
+.todo-form button {
+    padding: 10px 20px;
+    background-color: #3498db;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.todo-form button:hover {
+    background-color: #2980b9;
+}
+
+.todo-count {
+    color: #7f8c8d;
+    font-size: 14px;
+    margin-bottom: 12px;
+}
+
+.todo-item.completed {
+    opacity: 0.7;
+    border-left-color: #27ae60;
+}
+
+.todo-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.todo-header input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+}
+
+.todo-header h3 {
+    margin: 0;
+    font-size: 16px;
+}
+
+.todo-header h3.strikethrough {
+    text-decoration: line-through;
+    color: #95a5a6;
+}
+
+.todo-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 12px;
+}
+
+.category-badge {
+    font-size: 12px;
+    padding: 4px 10px;
+    border-radius: 12px;
+    color: white;
+}
+
+.delete-btn {
+    padding: 4px 12px;
+    background-color: #e74c3c;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.delete-btn:hover {
+    background-color: #c0392b;
+}
+
+/* Category manager styles */
+.category-manager h2 {
+    margin-bottom: 16px;
+    color: #2c3e50;
+}
+
+.add-category {
+    margin-bottom: 20px;
+}
+
+.add-category form {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.add-category input[type="text"] {
+    flex: 1;
+    padding: 10px 12px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+.add-category input[type="text"]:focus {
+    outline: none;
+    border-color: #3498db;
+}
+
+.add-category input[type="color"] {
+    width: 40px;
+    height: 38px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    cursor: pointer;
+    padding: 2px;
+}
+
+.add-category button {
+    padding: 10px 20px;
+    background-color: #3498db;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.add-category button:hover {
+    background-color: #2980b9;
+}
+
+.category-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.category-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px;
+    background-color: #f9f9f9;
+    border-radius: 4px;
+}
+
+.category-color {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+}
+
+.category-name {
+    flex: 1;
+    font-size: 14px;
+    color: #2c3e50;
+}


### PR DESCRIPTION
## Summary
- TodoList component now fetches from `/api/todos` on load
- Add create todo form with title input
- Add toggle complete functionality via checkbox
- Add delete todo functionality with delete button
- CategoryManager component fetches and manages categories via API
- Add styles for todo and category components

## Test plan
- [ ] Navigate to Todos view, verify todos load from API
- [ ] Create a new todo using the form
- [ ] Toggle a todo's completed status via checkbox
- [ ] Delete a todo using the delete button
- [ ] Navigate to Categories view, verify categories load
- [ ] Create a new category with name and color
- [ ] Delete a category