### PR TITLE
Add container build workflow with GHCR push

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-backend:
-    name: Build Backend Binary
+    name: Build Backend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -98,8 +98,8 @@ jobs:
           path: crates/frontend/dist
           retention-days: 1
 
-  push-backend:
-    name: Push Backend Container
+  container-backend:
+    name: Container Backend
     runs-on: ubuntu-latest
     needs: build-backend
     permissions:
@@ -118,6 +118,7 @@ jobs:
         run: chmod +x target/release/backend
 
       - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -131,7 +132,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/backend
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
@@ -145,8 +145,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  push-frontend:
-    name: Push Frontend Container
+  container-frontend:
+    name: Container Frontend
     runs-on: ubuntu-latest
     needs: build-frontend
     permissions:
@@ -162,6 +162,7 @@ jobs:
           path: crates/frontend/dist
 
       - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -175,7 +176,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/frontend
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build and push container images to GHCR
- Uses Rust caching for faster builds
- Builds binaries first, then creates minimal container images
- Pushes to `ghcr.io/meawoppl/agentive-inversion/backend` and `ghcr.io/meawoppl/agentive-inversion/frontend`

## How it works
1. **Build jobs** (with Rust caching):
   - `build-backend`: Compiles release binary, uploads as artifact
   - `build-frontend`: Runs `trunk build --release`, uploads dist as artifact

2. **Push jobs** (depend on build jobs):
   - Downloads artifacts from build step
   - Builds minimal Docker images (just copies pre-built binaries)
   - Pushes to GHCR on main branch and tags

## Image tags
- `main` - Latest from main branch
- `sha-abc1234` - Specific commit
- `v1.0.0` - Version tags (when pushed)
- `1.0` - Major.minor version

## Test plan
- [ ] Verify workflow runs on PR (builds but doesn't push)
- [ ] Merge and verify images are pushed to GHCR
- [ ] Pull and run containers locally