### PR TITLE
Add rule matching engine for email processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3254,8 +3254,10 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "diesel",
+ "regex",
  "serde",
  "serde_json",
+ "tracing",
  "uuid",
 ]
 
@@ -3823,9 +3825,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -3835,9 +3837,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3846,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",

--- a/crates/email-poller/src/processor.rs
+++ b/crates/email-poller/src/processor.rs
@@ -1,63 +1,337 @@
-use crate::gmail_client::EmailMessage;
-use chrono::Utc;
-use shared_types::Todo;
+use crate::db::{self, DbPool, Email};
+use shared_types::{
+    build_todo_action_from_rule, AgentRule, EmailMatchInput, ProposedTodoAction, ReasoningDetails,
+    RuleEngine, RuleMatchResult,
+};
 use uuid::Uuid;
 
-/// Process an email into a todo item
+/// Convert a database Email to EmailMatchInput for rule matching
+pub fn email_to_match_input(email: &Email) -> EmailMatchInput {
+    EmailMatchInput {
+        from_address: email.from_address.clone(),
+        from_name: email.from_name.clone(),
+        subject: email.subject.clone(),
+        body_text: email.body_text.clone(),
+        snippet: email.snippet.clone(),
+        labels: email
+            .labels
+            .as_ref()
+            .map(|l| l.iter().filter_map(|s| s.clone()).collect())
+            .unwrap_or_default(),
+        to_addresses: email
+            .to_addresses
+            .iter()
+            .filter_map(|s| s.clone())
+            .collect(),
+        cc_addresses: email
+            .cc_addresses
+            .as_ref()
+            .map(|l| l.iter().filter_map(|s| s.clone()).collect())
+            .unwrap_or_default(),
+    }
+}
+
+/// Result of processing an email through the rule engine
+#[derive(Debug)]
+pub struct EmailProcessingResult {
+    pub email_id: Uuid,
+    pub gmail_id: String,
+    pub decision_type: String,
+    pub proposed_action: ProposedTodoAction,
+    pub reasoning: String,
+    pub reasoning_details: ReasoningDetails,
+    pub confidence: f32,
+    pub matched_rule: Option<RuleMatchResult>,
+    pub auto_execute: bool,
+}
+
+/// Process an email through the rule engine
 ///
-/// Simple keyword-based heuristic. In production you'd want:
-/// - AI/NLP to extract action items
-/// - Better filtering of newsletters, spam, etc.
-/// - Due date extraction from email text
-pub fn process_email_to_todo(email: &EmailMessage) -> Option<Todo> {
-    let subject_lower = email.subject.to_lowercase();
+/// Returns a processing result with:
+/// - The matched rule (if any)
+/// - The proposed action
+/// - Whether to auto-execute or propose for user review
+pub fn process_email_with_rules(
+    email: &Email,
+    rules: &[AgentRule],
+) -> Option<EmailProcessingResult> {
+    let input = email_to_match_input(email);
 
-    // Check for actionable keywords in subject
-    let is_actionable = subject_lower.contains("todo")
-        || subject_lower.contains("action required")
-        || subject_lower.contains("action needed")
-        || subject_lower.contains("please review")
-        || subject_lower.contains("urgent")
-        || subject_lower.contains("asap")
-        || subject_lower.contains("deadline")
-        || subject_lower.contains("reminder");
+    // Try to match against rules first
+    if let Some(rule_match) = RuleEngine::get_best_match(rules, &input) {
+        // Rule matched - determine action based on rule
+        let proposed_action = build_todo_action_from_rule(&rule_match.action_params, &input);
 
-    if !is_actionable {
+        let reasoning = format!(
+            "Matched rule '{}': {}",
+            rule_match.rule_name,
+            rule_match.matched_clauses.join(", ")
+        );
+
+        let reasoning_details = ReasoningDetails {
+            matched_keywords: Some(rule_match.matched_clauses.clone()),
+            detected_deadline: None,
+            sender_frequency: None,
+            thread_length: None,
+            heuristic_score: None,
+            llm_analysis: None,
+        };
+
+        return Some(EmailProcessingResult {
+            email_id: email.id,
+            gmail_id: email.gmail_id.clone(),
+            decision_type: rule_match.action.clone(),
+            proposed_action,
+            reasoning,
+            reasoning_details,
+            confidence: 1.0, // Rules are high confidence
+            matched_rule: Some(rule_match),
+            auto_execute: true, // Rules auto-execute
+        });
+    }
+
+    // No rule matched - fall back to heuristic detection
+    process_email_with_heuristics(email, &input)
+}
+
+/// Actionable keywords to detect in emails
+const ACTIONABLE_KEYWORDS: &[&str] = &[
+    "todo",
+    "action required",
+    "action needed",
+    "please review",
+    "urgent",
+    "asap",
+    "deadline",
+    "reminder",
+    "follow up",
+    "followup",
+    "respond",
+    "reply needed",
+    "awaiting your",
+    "your input",
+    "by end of day",
+    "eod",
+    "by friday",
+    "by monday",
+];
+
+/// Process an email using keyword heuristics (fallback when no rules match)
+fn process_email_with_heuristics(
+    email: &Email,
+    input: &EmailMatchInput,
+) -> Option<EmailProcessingResult> {
+    let subject_lower = input.subject.to_lowercase();
+    let body_lower = input
+        .body_text
+        .as_ref()
+        .map(|b| b.to_lowercase())
+        .unwrap_or_default();
+    let content = format!("{} {}", subject_lower, body_lower);
+
+    // Find matching keywords
+    let matched_keywords: Vec<String> = ACTIONABLE_KEYWORDS
+        .iter()
+        .filter(|kw| content.contains(*kw))
+        .map(|s| s.to_string())
+        .collect();
+
+    if matched_keywords.is_empty() {
         return None;
     }
 
-    // Build todo title from subject
-    let title = if email.subject.len() > 100 {
-        format!("{}...", &email.subject[..97])
-    } else {
-        email.subject.clone()
+    // Calculate confidence based on number of keywords and their location
+    let subject_matches = ACTIONABLE_KEYWORDS
+        .iter()
+        .filter(|kw| subject_lower.contains(*kw))
+        .count();
+    let confidence = match (subject_matches, matched_keywords.len()) {
+        (s, _) if s >= 2 => 0.9,
+        (1, t) if t >= 2 => 0.8,
+        (1, _) => 0.7,
+        (0, t) if t >= 3 => 0.6,
+        (0, t) if t >= 2 => 0.5,
+        _ => 0.4,
     };
 
-    // Build description with snippet and sender
-    let description = if let Some(body) = &email.body {
-        let truncated = if body.len() > 500 {
-            format!("{}...", &body[..497])
-        } else {
-            body.clone()
-        };
-        Some(format!("{}\n\n---\nFrom: {}", truncated, email.from))
-    } else {
-        Some(format!("{}\n\n---\nFrom: {}", email.snippet, email.from))
+    let proposed_action = build_todo_action_from_rule(&None, input);
+
+    let reasoning = format!(
+        "Detected actionable keywords in email: {}",
+        matched_keywords.join(", ")
+    );
+
+    let reasoning_details = ReasoningDetails {
+        matched_keywords: Some(matched_keywords),
+        detected_deadline: None,
+        sender_frequency: None,
+        thread_length: None,
+        heuristic_score: Some(confidence),
+        llm_analysis: None,
     };
 
-    let now = Utc::now();
-    Some(Todo {
-        id: Uuid::new_v4(),
-        title,
-        description,
-        completed: false,
-        source: "email".to_string(),
-        source_id: Some(email.id.clone()),
-        due_date: None,
-        created_at: email.received_at.unwrap_or(now),
-        updated_at: now,
-        link: None,
-        category_id: None,
-        decision_id: None, // Will be set when created via agent decision flow
+    Some(EmailProcessingResult {
+        email_id: email.id,
+        gmail_id: email.gmail_id.clone(),
+        decision_type: "create_todo".to_string(),
+        proposed_action,
+        reasoning,
+        reasoning_details,
+        confidence,
+        matched_rule: None,
+        auto_execute: false, // Heuristics require user review
     })
+}
+
+/// Process unprocessed emails, creating decisions and optionally executing them
+pub async fn process_pending_emails(pool: &DbPool, limit: i64) -> anyhow::Result<ProcessingStats> {
+    let mut conn = pool.get().await?;
+
+    // Get active rules once for all emails
+    let rules = db::get_active_email_rules(&mut conn).await?;
+    tracing::debug!("Loaded {} active email rules", rules.len());
+
+    // Get unprocessed emails
+    let emails = db::get_unprocessed_emails(&mut conn, limit).await?;
+    tracing::info!("Processing {} unprocessed emails", emails.len());
+
+    let mut stats = ProcessingStats::default();
+
+    for email in emails {
+        match process_single_email(&mut conn, &email, &rules).await {
+            Ok(result) => {
+                stats.processed += 1;
+                match result {
+                    ProcessedEmailOutcome::RuleMatched => stats.rule_matched += 1,
+                    ProcessedEmailOutcome::HeuristicProposed => stats.heuristic_proposed += 1,
+                    ProcessedEmailOutcome::Ignored => stats.ignored += 1,
+                }
+            }
+            Err(e) => {
+                stats.errors += 1;
+                tracing::error!("Failed to process email {}: {}", email.id, e);
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
+#[derive(Debug, Default)]
+pub struct ProcessingStats {
+    pub processed: usize,
+    pub rule_matched: usize,
+    pub heuristic_proposed: usize,
+    pub ignored: usize,
+    pub errors: usize,
+}
+
+#[derive(Debug)]
+enum ProcessedEmailOutcome {
+    RuleMatched,
+    HeuristicProposed,
+    Ignored,
+}
+
+/// Process a single email
+async fn process_single_email(
+    conn: &mut diesel_async::AsyncPgConnection,
+    email: &Email,
+    rules: &[AgentRule],
+) -> anyhow::Result<ProcessedEmailOutcome> {
+    let result = process_email_with_rules(email, rules);
+
+    let outcome = match result {
+        Some(processing_result) => {
+            // Serialize proposed action and reasoning details
+            let proposed_action_json = serde_json::to_string(&processing_result.proposed_action)?;
+            let reasoning_details_json =
+                serde_json::to_string(&processing_result.reasoning_details)?;
+
+            // Determine status based on whether to auto-execute
+            let (status, applied_rule_id) = if processing_result.auto_execute {
+                if let Some(ref rule_match) = processing_result.matched_rule {
+                    ("auto_approved", Some(rule_match.rule_id))
+                } else {
+                    ("proposed", None)
+                }
+            } else {
+                ("proposed", None)
+            };
+
+            // Create the decision
+            let decision_id = db::create_decision(
+                conn,
+                "email",
+                Some(email.id),
+                Some(&email.gmail_id),
+                &processing_result.decision_type,
+                &proposed_action_json,
+                &processing_result.reasoning,
+                Some(&reasoning_details_json),
+                processing_result.confidence,
+                status,
+                applied_rule_id,
+            )
+            .await?;
+
+            tracing::info!(
+                "Created decision {} for email {} (status: {}, action: {})",
+                decision_id,
+                email.gmail_id,
+                status,
+                processing_result.decision_type
+            );
+
+            // If rule matched, increment match count
+            if let Some(ref rule_match) = processing_result.matched_rule {
+                db::increment_rule_match_count(conn, rule_match.rule_id).await?;
+            }
+
+            // If auto-approved and action is create_todo, create the todo immediately
+            if status == "auto_approved" && processing_result.decision_type == "create_todo" {
+                let todo_id = db::create_todo_from_decision(
+                    conn,
+                    decision_id,
+                    &processing_result.proposed_action.todo_title,
+                    processing_result
+                        .proposed_action
+                        .todo_description
+                        .as_deref(),
+                    "email",
+                    Some(&email.gmail_id),
+                    processing_result.proposed_action.due_date,
+                    processing_result.proposed_action.category_id,
+                )
+                .await?;
+
+                db::update_decision_result_todo(conn, decision_id, todo_id).await?;
+
+                tracing::info!(
+                    "Auto-created todo {} from decision {} for email {}",
+                    todo_id,
+                    decision_id,
+                    email.gmail_id
+                );
+            }
+
+            if processing_result.matched_rule.is_some() {
+                ProcessedEmailOutcome::RuleMatched
+            } else {
+                ProcessedEmailOutcome::HeuristicProposed
+            }
+        }
+        None => {
+            tracing::debug!(
+                "Email {} not actionable, marking as processed",
+                email.gmail_id
+            );
+            ProcessedEmailOutcome::Ignored
+        }
+    };
+
+    // Mark email as processed
+    db::mark_email_processed(conn, email.id).await?;
+
+    Ok(outcome)
 }

--- a/crates/email-poller/src/schema.rs
+++ b/crates/email-poller/src/schema.rs
@@ -1,6 +1,47 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    agent_rules (id) {
+        id -> Uuid,
+        name -> Varchar,
+        description -> Nullable<Text>,
+        source_type -> Varchar,
+        rule_type -> Varchar,
+        conditions -> Text,
+        action -> Varchar,
+        action_params -> Nullable<Text>,
+        priority -> Int4,
+        is_active -> Bool,
+        created_from_decision_id -> Nullable<Uuid>,
+        match_count -> Int4,
+        last_matched_at -> Nullable<Timestamptz>,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    agent_decisions (id) {
+        id -> Uuid,
+        source_type -> Varchar,
+        source_id -> Nullable<Uuid>,
+        source_external_id -> Nullable<Varchar>,
+        decision_type -> Varchar,
+        proposed_action -> Text,
+        reasoning -> Text,
+        reasoning_details -> Nullable<Text>,
+        confidence -> Float4,
+        status -> Varchar,
+        applied_rule_id -> Nullable<Uuid>,
+        result_todo_id -> Nullable<Uuid>,
+        user_feedback -> Nullable<Text>,
+        created_at -> Timestamptz,
+        reviewed_at -> Nullable<Timestamptz>,
+        executed_at -> Nullable<Timestamptz>,
+    }
+}
+
+diesel::table! {
     calendar_accounts (id) {
         id -> Uuid,
         account_name -> Varchar,
@@ -80,6 +121,7 @@ diesel::table! {
         updated_at -> Timestamptz,
         link -> Nullable<Varchar>,
         category_id -> Nullable<Uuid>,
+        decision_id -> Nullable<Uuid>,
     }
 }
 
@@ -87,6 +129,8 @@ diesel::joinable!(emails -> email_accounts (account_id));
 diesel::joinable!(todos -> categories (category_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
+    agent_rules,
+    agent_decisions,
     calendar_accounts,
     categories,
     email_accounts,

--- a/crates/shared-types/Cargo.toml
+++ b/crates/shared-types/Cargo.toml
@@ -12,3 +12,5 @@ serde_json.workspace = true
 chrono.workspace = true
 uuid.workspace = true
 diesel = { workspace = true, optional = true }
+regex = "1.12.2"
+tracing = "0.1.44"


### PR DESCRIPTION
## Summary
- Add `RuleEngine` in shared-types for evaluating rules against emails
- Integrate rule engine into email-poller processor
- Auto-execute rule matches, propose heuristic matches for user review
- Create agent_decisions with full audit trail

## Test plan
- [x] 8 unit tests pass for rule matching logic
- [ ] Manual test with real rules and emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)