### PR TITLE
Consolidate Google OAuth environment variables

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -130,10 +130,8 @@ cargo clippy --workspace         # Lint code
 
 Required variables (see `.env.example`):
 - `DATABASE_URL` - Neon PostgreSQL connection string
-- `GMAIL_CLIENT_ID` - Google OAuth client ID
-- `GMAIL_CLIENT_SECRET` - Google OAuth secret
-- `GOOGLE_CALENDAR_CLIENT_ID` - Calendar API client ID
-- `GOOGLE_CALENDAR_CLIENT_SECRET` - Calendar API secret
+- `GOOGLE_CLIENT_ID` - Google OAuth client ID (used for Gmail and Calendar APIs)
+- `GOOGLE_CLIENT_SECRET` - Google OAuth secret
 - `RUST_LOG` - Logging level (info, debug, etc.)
 
 ## Git Workflow Notes

--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,14 @@
 DATABASE_URL=postgres://user:password@db.neon.tech/agentive_inversion?sslmode=require
 
-# Gmail OAuth Configuration
+# Google OAuth Configuration (used for Gmail and Calendar APIs)
 # Create credentials at https://console.cloud.google.com/apis/credentials
-GMAIL_CLIENT_ID=your-client-id.apps.googleusercontent.com
-GMAIL_CLIENT_SECRET=your-client-secret
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-client-secret
 
 # Required: OAuth redirect URI for Gmail OAuth flow
 # For local development: http://localhost:3000/api/email-accounts/oauth/callback
 # For production: https://your-domain.com/api/email-accounts/oauth/callback
 OAUTH_REDIRECT_URI=http://localhost:3000/api/email-accounts/oauth/callback
-
-# Google Calendar API (for calendar-poller)
-GOOGLE_CALENDAR_CLIENT_ID=your-client-id.apps.googleusercontent.com
-GOOGLE_CALENDAR_CLIENT_SECRET=your-client-secret
 
 RUST_LOG=info
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,8 @@ Edit `.env` with your configuration:
 
 ```bash
 DATABASE_URL=postgres://user:password@db.neon.tech/agentive_inversion?sslmode=require
-GMAIL_CLIENT_ID=your-client-id.apps.googleusercontent.com
-GMAIL_CLIENT_SECRET=your-client-secret
-GOOGLE_CALENDAR_CLIENT_ID=your-client-id.apps.googleusercontent.com
-GOOGLE_CALENDAR_CLIENT_SECRET=your-client-secret
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-client-secret
 ```
 
 ### 3. Database Setup

--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -141,7 +141,7 @@ pub async fn start_gmail_oauth(
     Json(payload): Json<ConnectEmailAccountRequest>,
 ) -> Result<Json<OAuthStartResponse>, StatusCode> {
     let client_id =
-        std::env::var("GMAIL_CLIENT_ID").map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        std::env::var("GOOGLE_CLIENT_ID").map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     // Create a placeholder email account to track this connection
     let mut conn = pool
@@ -199,12 +199,12 @@ pub async fn gmail_oauth_callback(
         Err(_) => return Redirect::to("/oauth/error?msg=invalid_state").into_response(),
     };
 
-    let client_id = match std::env::var("GMAIL_CLIENT_ID") {
+    let client_id = match std::env::var("GOOGLE_CLIENT_ID") {
         Ok(client_id_str) => client_id_str,
         Err(_) => return Redirect::to("/oauth/error?msg=missing_config").into_response(),
     };
 
-    let client_secret = match std::env::var("GMAIL_CLIENT_SECRET") {
+    let client_secret = match std::env::var("GOOGLE_CLIENT_SECRET") {
         Ok(secret) => secret,
         Err(_) => return Redirect::to("/oauth/error?msg=missing_config").into_response(),
     };


### PR DESCRIPTION
## Summary
- Consolidate `GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET` and `GOOGLE_CALENDAR_CLIENT_ID` / `GOOGLE_CALENDAR_CLIENT_SECRET` into a single `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` pair
- Update `.env.example` with consolidated variables
- Update `handlers.rs` to use the new env var names
- Update documentation in `README.md` and `.claude/CLAUDE.md`

## Test plan
- [ ] Verify OAuth flow works with new env var names
- [ ] Check that Gmail and Calendar APIs both work with shared credentials