### PR TITLE
Require OAUTH_REDIRECT_URI environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,10 @@ DATABASE_URL=postgres://user:password@db.neon.tech/agentive_inversion?sslmode=re
 GMAIL_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GMAIL_CLIENT_SECRET=your-client-secret
 
-# Optional: OAuth redirect URI (defaults to http://localhost:3000/api/email-accounts/oauth/callback)
-# OAUTH_REDIRECT_URI=http://localhost:3000/api/email-accounts/oauth/callback
+# Required: OAuth redirect URI for Gmail OAuth flow
+# For local development: http://localhost:3000/api/email-accounts/oauth/callback
+# For production: https://your-domain.com/api/email-accounts/oauth/callback
+OAUTH_REDIRECT_URI=http://localhost:3000/api/email-accounts/oauth/callback
 
 # Google Calendar API (for calendar-poller)
 GOOGLE_CALENDAR_CLIENT_ID=your-client-id.apps.googleusercontent.com


### PR DESCRIPTION
## Summary
- Makes `OAUTH_REDIRECT_URI` required instead of defaulting to localhost
- Returns proper error if the variable is missing
- Updates `.env.example` to document the requirement

Fixes #27

## Test plan
- [x] Run `cargo clippy -p backend --all-features` - no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)