### PR TITLE
Configure CORS based on CORS_ALLOWED_ORIGINS environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,9 @@ GOOGLE_CALENDAR_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CALENDAR_CLIENT_SECRET=your-client-secret
 
 RUST_LOG=info
+
+# CORS Configuration (optional for development, required for production)
+# Comma-separated list of allowed origins
+# For local development, leave unset to allow all origins
+# For production: CORS_ALLOWED_ORIGINS=https://your-frontend.com,https://admin.your-frontend.com
+# CORS_ALLOWED_ORIGINS=http://localhost:8080


### PR DESCRIPTION
## Summary
- Replaces permissive CORS with configurable allowed origins
- Reads `CORS_ALLOWED_ORIGINS` environment variable (comma-separated list)
- Falls back to permissive CORS (with warning) when not set for dev compatibility
- Configures specific allowed methods and headers when origins are specified
- Updates `.env.example` with CORS configuration documentation

Fixes #30

## Test plan
- [x] Run `cargo clippy -p backend --all-features` - no warnings
- Backend starts with permissive CORS when `CORS_ALLOWED_ORIGINS` is not set (dev mode)
- Backend restricts origins when `CORS_ALLOWED_ORIGINS` is set (production mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)