### PR TITLE
Replace expect() with proper error handling for DATABASE_URL

### DIFF
--- a/crates/backend/src/db.rs
+++ b/crates/backend/src/db.rs
@@ -37,7 +37,8 @@ async fn establish_tls_connection(config: String) -> diesel::ConnectionResult<As
 }
 
 pub fn establish_connection_pool() -> anyhow::Result<DbPool> {
-    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let database_url = std::env::var("DATABASE_URL")
+        .map_err(|_| anyhow::anyhow!("DATABASE_URL environment variable must be set"))?;
 
     let mut manager_config = ManagerConfig::default();
     manager_config.custom_setup =

--- a/crates/email-poller/src/db.rs
+++ b/crates/email-poller/src/db.rs
@@ -32,7 +32,8 @@ async fn establish_tls_connection(config: String) -> diesel::ConnectionResult<As
 }
 
 pub fn establish_connection_pool() -> anyhow::Result<DbPool> {
-    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let database_url = std::env::var("DATABASE_URL")
+        .map_err(|_| anyhow::anyhow!("DATABASE_URL environment variable must be set"))?;
 
     let mut manager_config = ManagerConfig::default();
     manager_config.custom_setup =


### PR DESCRIPTION
## Summary
- Replaces `.expect()` with proper `anyhow` error handling for `DATABASE_URL`
- Services now fail gracefully with clear error messages instead of panicking
- Updated both backend and email-poller db.rs files

Fixes #33

## Test plan
- [x] Run `cargo clippy --workspace --all-features` - no warnings
- Service logs clear error message when DATABASE_URL is missing
- Service exits cleanly instead of panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)