### PR TITLE
Move seed data injection to dev script only

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -27,7 +27,7 @@ docker-compose up --build
 
 This will:
 1. Start PostgreSQL database
-2. Build and start the backend (runs migrations + seeds test data)
+2. Build and start the backend (runs migrations)
 3. Build and start the frontend
 
 ### 2. Access the Application
@@ -49,7 +49,13 @@ docker-compose down -v
 
 ## Test Data
 
-The setup automatically seeds the database with sample data:
+To load sample test data, use the dev script:
+
+```bash
+./dev.sh db:seed
+```
+
+This loads `seed-data.sql` which includes:
 
 **Sample Todos:**
 - 5 manual todos (including completed items)
@@ -104,8 +110,11 @@ SELECT * FROM calendar_accounts;
 # Stop containers and remove volumes
 docker-compose down -v
 
-# Start fresh (will re-run migrations and seed data)
+# Start fresh (will re-run migrations)
 docker-compose up --build
+
+# Optionally load seed data
+./dev.sh db:seed
 ```
 
 ## Architecture

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -10,10 +10,9 @@ WORKDIR /app
 # Copy pre-built binary from host
 COPY ./target/release/backend /app/backend
 
-# Copy migrations and seed data
+# Copy migrations
 COPY migrations ./migrations
 COPY diesel.toml ./
-COPY seed-data.sql ./
 
 # Copy startup script
 COPY docker-entrypoint-backend.sh /app/

--- a/crates/shared-types/src/lib.rs
+++ b/crates/shared-types/src/lib.rs
@@ -1220,7 +1220,7 @@ mod tests {
 
         // Run multiple times to exercise cache
         for _ in 0..10 {
-            let results = RuleEngine::match_email(&[rule.clone()], &input);
+            let results = RuleEngine::match_email(std::slice::from_ref(&rule), &input);
             assert_eq!(results.len(), 1);
             assert!(results[0].matched);
         }

--- a/docker-entrypoint-backend.sh
+++ b/docker-entrypoint-backend.sh
@@ -20,11 +20,5 @@ for migration in /app/migrations/*/up.sql; do
   psql "$DATABASE_URL" -f "$migration" 2>&1 || echo "Migration already applied or failed: $migration"
 done
 
-# Check if seed data file exists
-if [ -f "/app/seed-data.sql" ]; then
-  echo "Loading seed data..."
-  psql "$DATABASE_URL" -f /app/seed-data.sql 2>&1 || echo "Seed data already loaded or failed"
-fi
-
 echo "Starting backend server..."
 exec /app/backend


### PR DESCRIPTION
## Summary
Removes automatic seed data injection from the Docker entrypoint. Seed data should only be loaded explicitly via the dev script.

### Changes
- Remove seed data loading from `docker-entrypoint-backend.sh`
- Remove `seed-data.sql` from `Dockerfile.backend`
- Update `DOCKER.md` to document using `./dev.sh db:seed` for test data

### Why
- Production deployments should not have test data injected
- Seed data is only useful during development/testing
- Users should explicitly opt-in to loading test data

### Usage
```bash
# Start containers
docker-compose up --build

# Load test data (optional)
./dev.sh db:seed
```

## Test plan
- [ ] `docker-compose up --build` starts with empty database (migrations only)
- [ ] `./dev.sh db:seed` successfully loads test data