### PR TITLE
Consolidate email poller into backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,12 +211,17 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "diesel",
  "diesel-async",
  "dotenvy",
  "futures",
+ "google-gmail1",
+ "hyper 1.8.1",
+ "hyper-util",
+ "regex",
  "reqwest",
  "rustls 0.23.35",
  "serde",
@@ -234,6 +239,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "webpki-roots",
+ "yup-oauth2 12.1.1",
 ]
 
 [[package]]

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -34,6 +34,13 @@ webpki-roots = "1.0.4"
 futures = "0.3.31"
 tokio-postgres = "0.7.15"
 clap = { version = "4.5.53", features = ["derive", "env"] }
+# Gmail polling (consolidated from email-poller crate)
+google-gmail1 = "6.0.0"
+yup-oauth2 = "12.1.1"
+base64 = "0.22.1"
+regex = "1"
+hyper = { version = "1.8.1", features = ["client"] }
+hyper-util = { version = "0.1.18", features = ["client-legacy"] }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -12,6 +12,7 @@ use tower_http::{
 mod db;
 mod handlers;
 mod models;
+mod pollers;
 mod schema;
 
 #[tokio::main]
@@ -22,6 +23,12 @@ async fn main() -> anyhow::Result<()> {
 
     // Establish database connection pool
     let pool = db::establish_connection_pool()?;
+
+    // Start email polling background task
+    let poll_pool = pool.clone();
+    tokio::spawn(async move {
+        pollers::start_email_polling_task(poll_pool).await;
+    });
 
     let app = Router::new()
         .route("/health", get(health_check))

--- a/crates/backend/src/models.rs
+++ b/crates/backend/src/models.rs
@@ -49,3 +49,24 @@ impl From<AgentDecisionRow> for shared_types::AgentDecision {
         }
     }
 }
+
+/// Insertable struct for new emails
+#[derive(Debug, Clone, Insertable)]
+#[diesel(table_name = crate::schema::emails)]
+pub struct NewEmail {
+    pub account_id: Uuid,
+    pub gmail_id: String,
+    pub thread_id: String,
+    pub history_id: Option<i64>,
+    pub subject: String,
+    pub from_address: String,
+    pub from_name: Option<String>,
+    pub to_addresses: Vec<Option<String>>,
+    pub cc_addresses: Option<Vec<Option<String>>>,
+    pub snippet: Option<String>,
+    pub body_text: Option<String>,
+    pub body_html: Option<String>,
+    pub labels: Option<Vec<Option<String>>>,
+    pub has_attachments: bool,
+    pub received_at: DateTime<Utc>,
+}

--- a/crates/backend/src/pollers/email.rs
+++ b/crates/backend/src/pollers/email.rs
@@ -1,0 +1,342 @@
+//! Email polling background task.
+//!
+//! This module runs as a tokio background task within the backend process,
+//! periodically fetching new emails from configured Gmail accounts.
+
+use super::gmail_client::{EmailMessage, GmailClient};
+use super::processor;
+use crate::db::{self, DbPool};
+use crate::models::NewEmail;
+use anyhow::{Context, Result};
+use chrono::Utc;
+use shared_types::EmailAccount;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+
+/// Configuration for the email polling task
+#[derive(Debug, Clone)]
+pub struct EmailPollerConfig {
+    /// How often to poll for new emails (default: 5 minutes)
+    pub poll_interval: Duration,
+    /// Minimum seconds between polls per account (rate limiting)
+    pub rate_limit_secs: u64,
+    /// Maximum emails to fetch per poll
+    pub max_fetch_per_poll: u32,
+    /// Maximum unprocessed emails to process per cycle
+    pub max_process_per_cycle: i64,
+}
+
+impl Default for EmailPollerConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(300), // 5 minutes
+            rate_limit_secs: 60,                     // 1 minute minimum between polls
+            max_fetch_per_poll: 50,
+            max_process_per_cycle: 100,
+        }
+    }
+}
+
+impl EmailPollerConfig {
+    /// Load configuration from environment variables
+    pub fn from_env() -> Self {
+        let poll_interval_secs = std::env::var("EMAIL_POLL_INTERVAL_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(300);
+
+        let rate_limit_secs = std::env::var("EMAIL_RATE_LIMIT_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(60);
+
+        let max_fetch_per_poll = std::env::var("EMAIL_MAX_FETCH_PER_POLL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(50);
+
+        let max_process_per_cycle = std::env::var("EMAIL_MAX_PROCESS_PER_CYCLE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(100);
+
+        Self {
+            poll_interval: Duration::from_secs(poll_interval_secs),
+            rate_limit_secs,
+            max_fetch_per_poll,
+            max_process_per_cycle,
+        }
+    }
+}
+
+/// Tracks the last poll time for each account (by email)
+struct RateLimiter {
+    last_poll: HashMap<String, Instant>,
+}
+
+impl RateLimiter {
+    fn new() -> Self {
+        Self {
+            last_poll: HashMap::new(),
+        }
+    }
+
+    fn can_poll(&self, email: &str, rate_limit_secs: u64) -> bool {
+        match self.last_poll.get(email) {
+            Some(last) => last.elapsed().as_secs() >= rate_limit_secs,
+            None => true,
+        }
+    }
+
+    fn record_poll(&mut self, email: &str) {
+        self.last_poll.insert(email.to_string(), Instant::now());
+    }
+}
+
+/// Account state tracked between polls
+#[derive(Debug, Clone, Default)]
+struct AccountState {
+    last_history_id: Option<u64>,
+}
+
+/// Start the email polling background task
+pub async fn start_email_polling_task(pool: DbPool) {
+    let config = EmailPollerConfig::from_env();
+
+    tracing::info!(
+        "Starting email polling task (interval: {:?}, rate limit: {}s)",
+        config.poll_interval,
+        config.rate_limit_secs
+    );
+
+    let mut rate_limiter = RateLimiter::new();
+    let mut account_states: HashMap<Uuid, AccountState> = HashMap::new();
+
+    loop {
+        if let Err(e) = run_poll_cycle(&pool, &config, &mut rate_limiter, &mut account_states).await
+        {
+            tracing::error!("Email poll cycle failed: {}", e);
+        }
+
+        tokio::time::sleep(config.poll_interval).await;
+    }
+}
+
+async fn run_poll_cycle(
+    pool: &DbPool,
+    config: &EmailPollerConfig,
+    rate_limiter: &mut RateLimiter,
+    account_states: &mut HashMap<Uuid, AccountState>,
+) -> Result<()> {
+    let mut conn = pool.get().await.context("Failed to get DB connection")?;
+
+    // Get active email accounts from database
+    let accounts = db::email_accounts::list_active(&mut conn).await?;
+
+    if accounts.is_empty() {
+        tracing::debug!("No active email accounts configured");
+        return Ok(());
+    }
+
+    tracing::debug!("Polling {} active email accounts", accounts.len());
+
+    for account in accounts {
+        // Check rate limiting
+        if !rate_limiter.can_poll(&account.email_address, config.rate_limit_secs) {
+            tracing::debug!("Skipping {} (rate limited)", account.email_address);
+            continue;
+        }
+
+        // Get or create account state
+        let state = account_states.entry(account.id).or_default();
+
+        match poll_single_account(&account, state, pool, config.max_fetch_per_poll).await {
+            Ok(result) => {
+                if result.count > 0 {
+                    tracing::info!(
+                        "Fetched {} new emails from {}",
+                        result.count,
+                        account.email_address
+                    );
+                }
+
+                // Update state for next poll
+                if let Some(history_id) = result.history_id {
+                    state.last_history_id = Some(history_id);
+                }
+
+                rate_limiter.record_poll(&account.email_address);
+            }
+            Err(e) => {
+                tracing::error!("Failed to poll {}: {}", account.email_address, e);
+
+                // Update sync status in database
+                if let Err(update_err) =
+                    db::email_accounts::update_sync_error(&mut conn, account.id, &e.to_string())
+                        .await
+                {
+                    tracing::error!("Failed to update sync error: {}", update_err);
+                }
+            }
+        }
+    }
+
+    // Process any unprocessed emails
+    match processor::process_pending_emails(pool, config.max_process_per_cycle).await {
+        Ok(stats) => {
+            if stats.processed > 0 {
+                tracing::info!(
+                    "Processed {} emails: {} rule matched, {} heuristic proposed, {} ignored, {} errors",
+                    stats.processed,
+                    stats.rule_matched,
+                    stats.heuristic_proposed,
+                    stats.ignored,
+                    stats.errors
+                );
+            }
+        }
+        Err(e) => {
+            tracing::error!("Failed to process pending emails: {}", e);
+        }
+    }
+
+    Ok(())
+}
+
+struct PollResult {
+    count: usize,
+    history_id: Option<u64>,
+}
+
+async fn poll_single_account(
+    account: &EmailAccount,
+    state: &AccountState,
+    pool: &DbPool,
+    max_fetch_per_poll: u32,
+) -> Result<PollResult> {
+    // Check if account has OAuth tokens
+    if account.oauth_refresh_token.is_none() {
+        return Err(anyhow::anyhow!(
+            "Account {} has no OAuth tokens configured",
+            account.email_address
+        ));
+    }
+
+    tracing::debug!("Polling {}...", account.email_address);
+
+    let client = GmailClient::from_account(account)
+        .await
+        .context("Failed to create Gmail client")?;
+
+    let emails = match state.last_history_id {
+        Some(history_id) if history_id > 0 => {
+            client
+                .fetch_messages_since(history_id, max_fetch_per_poll)
+                .await?
+        }
+        _ => client.fetch_messages(max_fetch_per_poll).await?,
+    };
+
+    let count = save_emails_to_db(&emails, account.id, pool).await?;
+
+    // Get current history ID for next sync
+    let history_id = client.get_history_id().await.ok();
+
+    Ok(PollResult { count, history_id })
+}
+
+async fn save_emails_to_db(
+    emails: &[EmailMessage],
+    account_id: Uuid,
+    pool: &DbPool,
+) -> Result<usize> {
+    let mut conn = pool.get().await.context("Failed to get DB connection")?;
+    let mut count = 0;
+
+    for email in emails {
+        // Parse "From" header into address and name
+        let (from_address, from_name) = parse_from_header(&email.from);
+
+        // Parse To addresses
+        let to_addresses: Vec<Option<String>> = email
+            .to
+            .iter()
+            .map(|addr| Some(parse_from_header(addr).0))
+            .collect();
+
+        // Parse CC addresses
+        let cc_addresses: Option<Vec<Option<String>>> = if email.cc.is_empty() {
+            None
+        } else {
+            Some(
+                email
+                    .cc
+                    .iter()
+                    .map(|addr| Some(parse_from_header(addr).0))
+                    .collect(),
+            )
+        };
+
+        // Labels as array
+        let labels: Option<Vec<Option<String>>> = if email.labels.is_empty() {
+            None
+        } else {
+            Some(email.labels.iter().map(|l| Some(l.clone())).collect())
+        };
+
+        let new_email = NewEmail {
+            account_id,
+            gmail_id: email.id.clone(),
+            thread_id: email.thread_id.clone(),
+            history_id: email.history_id.map(|h| h as i64),
+            subject: email.subject.clone(),
+            from_address,
+            from_name,
+            to_addresses,
+            cc_addresses,
+            snippet: Some(email.snippet.clone()),
+            body_text: email.body_text.clone(),
+            body_html: email.body_html.clone(),
+            labels,
+            has_attachments: email.has_attachments,
+            received_at: email.received_at.unwrap_or_else(Utc::now),
+        };
+
+        match db::emails::insert(&mut conn, new_email).await {
+            Ok(Some(_)) => {
+                tracing::debug!("  Stored: {} - {}", email.id, email.subject);
+                count += 1;
+            }
+            Ok(None) => {
+                tracing::trace!("  Skipped (duplicate): {}", email.id);
+            }
+            Err(e) => {
+                tracing::warn!("  Failed to store {}: {}", email.id, e);
+            }
+        }
+    }
+
+    Ok(count)
+}
+
+/// Parse a "From" header like "John Doe <john@example.com>" into (address, name)
+fn parse_from_header(from: &str) -> (String, Option<String>) {
+    let from = from.trim();
+
+    if let Some(bracket_start) = from.rfind('<') {
+        if let Some(bracket_end) = from.rfind('>') {
+            let address = from[bracket_start + 1..bracket_end].trim().to_string();
+            let name = from[..bracket_start].trim();
+            let name = name.trim_matches('"').trim();
+            let name = if name.is_empty() {
+                None
+            } else {
+                Some(name.to_string())
+            };
+            return (address, name);
+        }
+    }
+
+    (from.to_string(), None)
+}

--- a/crates/backend/src/pollers/gmail_client.rs
+++ b/crates/backend/src/pollers/gmail_client.rs
@@ -1,0 +1,386 @@
+//! Gmail API client for fetching and managing emails.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use google_gmail1::api::Message;
+use google_gmail1::hyper_rustls::HttpsConnector;
+use google_gmail1::Gmail;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioExecutor;
+use shared_types::EmailAccount;
+
+/// Client for interacting with Gmail API
+#[allow(dead_code)]
+pub struct GmailClient {
+    hub: Gmail<HttpsConnector<HttpConnector>>,
+    pub email_address: String,
+}
+
+/// Email message fetched from Gmail
+#[derive(Debug, Clone)]
+pub struct EmailMessage {
+    pub id: String,
+    pub thread_id: String,
+    pub subject: String,
+    pub from: String,
+    pub to: Vec<String>,
+    pub cc: Vec<String>,
+    pub snippet: String,
+    pub body_text: Option<String>,
+    pub body_html: Option<String>,
+    pub received_at: Option<DateTime<Utc>>,
+    pub history_id: Option<u64>,
+    pub labels: Vec<String>,
+    pub has_attachments: bool,
+}
+
+impl GmailClient {
+    /// Create a new Gmail client from an EmailAccount with stored OAuth tokens
+    pub async fn from_account(account: &EmailAccount) -> Result<Self> {
+        let refresh_token = account
+            .oauth_refresh_token
+            .as_ref()
+            .context("No refresh token stored for account")?;
+
+        let client_id = std::env::var("GOOGLE_CLIENT_ID")
+            .context("GOOGLE_CLIENT_ID environment variable must be set")?;
+        let client_secret = std::env::var("GOOGLE_CLIENT_SECRET")
+            .context("GOOGLE_CLIENT_SECRET environment variable must be set")?;
+
+        // Build AuthorizedUserSecret with our stored refresh token
+        // Use the yup_oauth2 re-exported by google_gmail1 to avoid version mismatch
+        let secret = google_gmail1::yup_oauth2::authorized_user::AuthorizedUserSecret {
+            client_id,
+            client_secret,
+            refresh_token: refresh_token.clone(),
+            key_type: "authorized_user".to_string(),
+        };
+
+        // Create authenticator using authorized user flow
+        let auth = google_gmail1::yup_oauth2::AuthorizedUserAuthenticator::builder(secret)
+            .build()
+            .await
+            .context("Failed to build authenticator from refresh token")?;
+
+        let connector = google_gmail1::hyper_rustls::HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .context("Failed to load native TLS roots")?
+            .https_or_http()
+            .enable_http1()
+            .build();
+
+        let client = Client::builder(TokioExecutor::new()).build(connector);
+        let hub = Gmail::new(client, auth);
+
+        Ok(Self {
+            hub,
+            email_address: account.email_address.clone(),
+        })
+    }
+
+    /// Fetch recent messages from inbox
+    pub async fn fetch_messages(&self, max_results: u32) -> Result<Vec<EmailMessage>> {
+        let (_, list_response) = self
+            .hub
+            .users()
+            .messages_list("me")
+            .add_label_ids("INBOX")
+            .max_results(max_results)
+            .doit()
+            .await
+            .context("Failed to list messages")?;
+
+        let messages = list_response.messages.unwrap_or_default();
+        let mut emails = Vec::new();
+
+        for msg in messages {
+            if let Some(id) = msg.id {
+                match self.get_message(&id).await {
+                    Ok(email) => emails.push(email),
+                    Err(e) => {
+                        tracing::warn!("Failed to fetch message {}: {}", id, e);
+                    }
+                }
+            }
+        }
+
+        Ok(emails)
+    }
+
+    /// Fetch messages since a history ID (incremental sync)
+    pub async fn fetch_messages_since(
+        &self,
+        history_id: u64,
+        max_results: u32,
+    ) -> Result<Vec<EmailMessage>> {
+        let (_, history_response) = self
+            .hub
+            .users()
+            .history_list("me")
+            .start_history_id(history_id)
+            .label_id("INBOX")
+            .add_history_types("messageAdded")
+            .max_results(max_results)
+            .doit()
+            .await
+            .context("Failed to list history")?;
+
+        let mut emails = Vec::new();
+        let mut seen_ids = std::collections::HashSet::new();
+
+        if let Some(history) = history_response.history {
+            for h in history {
+                if let Some(messages_added) = h.messages_added {
+                    for msg_added in messages_added {
+                        if let Some(message) = msg_added.message {
+                            if let Some(id) = message.id {
+                                if seen_ids.insert(id.clone()) {
+                                    match self.get_message(&id).await {
+                                        Ok(email) => emails.push(email),
+                                        Err(e) => {
+                                            tracing::warn!("Failed to fetch message {}: {}", id, e);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(emails)
+    }
+
+    /// Get the current history ID for the mailbox
+    pub async fn get_history_id(&self) -> Result<u64> {
+        let (_, profile) = self
+            .hub
+            .users()
+            .get_profile("me")
+            .doit()
+            .await
+            .context("Failed to get profile")?;
+
+        profile.history_id.context("No history ID in profile")
+    }
+
+    /// Get full message details
+    pub async fn get_message(&self, message_id: &str) -> Result<EmailMessage> {
+        let (_, message) = self
+            .hub
+            .users()
+            .messages_get("me", message_id)
+            .format("full")
+            .doit()
+            .await
+            .context("Failed to get message")?;
+
+        Ok(Self::parse_message(message))
+    }
+
+    /// Archive a message (remove INBOX label)
+    #[allow(dead_code)]
+    pub async fn archive_message(&self, message_id: &str) -> Result<()> {
+        let modify_request = google_gmail1::api::ModifyMessageRequest {
+            remove_label_ids: Some(vec!["INBOX".to_string()]),
+            add_label_ids: None,
+        };
+
+        self.hub
+            .users()
+            .messages_modify(modify_request, "me", message_id)
+            .doit()
+            .await
+            .context("Failed to archive message")?;
+
+        tracing::info!("Archived message: {}", message_id);
+        Ok(())
+    }
+
+    fn parse_message(message: Message) -> EmailMessage {
+        let id = message.id.clone().unwrap_or_default();
+        let thread_id = message.thread_id.clone().unwrap_or_default();
+        let snippet = message.snippet.clone().unwrap_or_default();
+        let history_id = message.history_id;
+        let labels = message.label_ids.clone().unwrap_or_default();
+
+        let mut subject = String::new();
+        let mut from = String::new();
+        let mut to = Vec::new();
+        let mut cc = Vec::new();
+        let mut received_at = None;
+
+        if let Some(payload) = &message.payload {
+            if let Some(headers) = &payload.headers {
+                for header in headers {
+                    match header.name.as_deref() {
+                        Some("Subject") => subject = header.value.clone().unwrap_or_default(),
+                        Some("From") => from = header.value.clone().unwrap_or_default(),
+                        Some("To") => {
+                            if let Some(val) = &header.value {
+                                to = Self::parse_address_list(val);
+                            }
+                        }
+                        Some("Cc") => {
+                            if let Some(val) = &header.value {
+                                cc = Self::parse_address_list(val);
+                            }
+                        }
+                        Some("Date") => {
+                            if let Some(date_str) = &header.value {
+                                received_at = Self::parse_date(date_str);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        let (body_text, body_html) = Self::extract_bodies(&message);
+        let has_attachments = Self::detect_attachments(&message);
+
+        EmailMessage {
+            id,
+            thread_id,
+            subject,
+            from,
+            to,
+            cc,
+            snippet,
+            body_text,
+            body_html,
+            received_at,
+            history_id,
+            labels,
+            has_attachments,
+        }
+    }
+
+    fn parse_date(date_str: &str) -> Option<DateTime<Utc>> {
+        if let Ok(dt) = DateTime::parse_from_rfc2822(date_str) {
+            return Some(dt.with_timezone(&Utc));
+        }
+        None
+    }
+
+    fn parse_address_list(header_value: &str) -> Vec<String> {
+        header_value
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    }
+
+    fn extract_bodies(message: &Message) -> (Option<String>, Option<String>) {
+        let payload = match message.payload.as_ref() {
+            Some(p) => p,
+            None => return (None, None),
+        };
+
+        let mut text_body = None;
+        let mut html_body = None;
+
+        if let Some(body) = &payload.body {
+            if let Some(data) = &body.data {
+                if let Some(decoded) = Self::bytes_to_string(data) {
+                    match payload.mime_type.as_deref() {
+                        Some("text/plain") => text_body = Some(decoded),
+                        Some("text/html") => html_body = Some(decoded),
+                        _ => text_body = Some(decoded),
+                    }
+                }
+            }
+        }
+
+        if let Some(parts) = &payload.parts {
+            Self::extract_bodies_from_parts(parts, &mut text_body, &mut html_body);
+        }
+
+        (text_body, html_body)
+    }
+
+    fn extract_bodies_from_parts(
+        parts: &[google_gmail1::api::MessagePart],
+        text_body: &mut Option<String>,
+        html_body: &mut Option<String>,
+    ) {
+        for part in parts {
+            match part.mime_type.as_deref() {
+                Some("text/plain") if text_body.is_none() => {
+                    if let Some(body) = &part.body {
+                        if let Some(data) = &body.data {
+                            if let Some(decoded) = Self::bytes_to_string(data) {
+                                *text_body = Some(decoded);
+                            }
+                        }
+                    }
+                }
+                Some("text/html") if html_body.is_none() => {
+                    if let Some(body) = &part.body {
+                        if let Some(data) = &body.data {
+                            if let Some(decoded) = Self::bytes_to_string(data) {
+                                *html_body = Some(decoded);
+                            }
+                        }
+                    }
+                }
+                Some(mime) if mime.starts_with("multipart/") => {
+                    if let Some(nested_parts) = &part.parts {
+                        Self::extract_bodies_from_parts(nested_parts, text_body, html_body);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn bytes_to_string(data: &[u8]) -> Option<String> {
+        String::from_utf8(data.to_vec()).ok()
+    }
+
+    fn detect_attachments(message: &Message) -> bool {
+        let payload = match message.payload.as_ref() {
+            Some(p) => p,
+            None => return false,
+        };
+
+        if let Some(parts) = &payload.parts {
+            return Self::has_attachments_in_parts(parts);
+        }
+
+        false
+    }
+
+    fn has_attachments_in_parts(parts: &[google_gmail1::api::MessagePart]) -> bool {
+        for part in parts {
+            if let Some(filename) = &part.filename {
+                if !filename.is_empty() {
+                    return true;
+                }
+            }
+
+            if let Some(headers) = &part.headers {
+                for header in headers {
+                    if header.name.as_deref() == Some("Content-Disposition") {
+                        if let Some(value) = &header.value {
+                            if value.starts_with("attachment") {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if let Some(nested_parts) = &part.parts {
+                if Self::has_attachments_in_parts(nested_parts) {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+}

--- a/crates/backend/src/pollers/mod.rs
+++ b/crates/backend/src/pollers/mod.rs
@@ -1,0 +1,10 @@
+//! Background polling tasks for email and calendar integration.
+//!
+//! This module consolidates the email-poller functionality into the backend,
+//! running as tokio background tasks rather than separate processes.
+
+pub mod email;
+mod gmail_client;
+mod processor;
+
+pub use email::start_email_polling_task;

--- a/crates/backend/src/pollers/processor.rs
+++ b/crates/backend/src/pollers/processor.rs
@@ -1,0 +1,364 @@
+//! Email processing logic using rules and heuristics.
+
+use crate::db::{self, emails::Email, DbPool};
+use shared_types::{
+    build_todo_action_from_rule, AgentRule, DecisionStatus, DecisionType, EmailMatchInput,
+    ProposedTodoAction, ReasoningDetails, RuleEngine, RuleMatchResult,
+};
+use uuid::Uuid;
+
+/// Convert a database Email to EmailMatchInput for rule matching
+pub fn email_to_match_input(email: &Email) -> EmailMatchInput {
+    EmailMatchInput {
+        from_address: email.from_address.clone(),
+        from_name: email.from_name.clone(),
+        subject: email.subject.clone(),
+        body_text: email.body_text.clone(),
+        snippet: email.snippet.clone(),
+        labels: email
+            .labels
+            .as_ref()
+            .map(|l| l.iter().filter_map(|s| s.clone()).collect())
+            .unwrap_or_default(),
+        to_addresses: email
+            .to_addresses
+            .iter()
+            .filter_map(|s| s.clone())
+            .collect(),
+        cc_addresses: email
+            .cc_addresses
+            .as_ref()
+            .map(|l| l.iter().filter_map(|s| s.clone()).collect())
+            .unwrap_or_default(),
+    }
+}
+
+/// Result of processing an email through the rule engine
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct EmailProcessingResult {
+    pub email_id: Uuid,
+    pub gmail_id: String,
+    pub decision_type: String,
+    pub proposed_action: ProposedTodoAction,
+    pub reasoning: String,
+    pub reasoning_details: ReasoningDetails,
+    pub confidence: f32,
+    pub matched_rule: Option<RuleMatchResult>,
+    pub auto_execute: bool,
+}
+
+/// Process an email through the rule engine
+pub fn process_email_with_rules(
+    email: &Email,
+    rules: &[AgentRule],
+) -> Option<EmailProcessingResult> {
+    let input = email_to_match_input(email);
+
+    // Try to match against rules first
+    if let Some(rule_match) = RuleEngine::get_best_match(rules, &input) {
+        let proposed_action = build_todo_action_from_rule(&rule_match.action_params, &input);
+
+        let reasoning = format!(
+            "Matched rule '{}': {}",
+            rule_match.rule_name,
+            rule_match.matched_clauses.join(", ")
+        );
+
+        let reasoning_details = ReasoningDetails {
+            matched_keywords: Some(rule_match.matched_clauses.clone()),
+            detected_deadline: None,
+            sender_frequency: None,
+            thread_length: None,
+            heuristic_score: None,
+            llm_analysis: None,
+        };
+
+        return Some(EmailProcessingResult {
+            email_id: email.id,
+            gmail_id: email.gmail_id.clone(),
+            decision_type: rule_match.action.clone(),
+            proposed_action,
+            reasoning,
+            reasoning_details,
+            confidence: 1.0,
+            matched_rule: Some(rule_match),
+            auto_execute: true,
+        });
+    }
+
+    // No rule matched - fall back to heuristic detection
+    process_email_with_heuristics(email, &input)
+}
+
+/// Actionable keywords to detect in emails
+const ACTIONABLE_KEYWORDS: &[&str] = &[
+    "todo",
+    "action required",
+    "action needed",
+    "please review",
+    "urgent",
+    "asap",
+    "deadline",
+    "reminder",
+    "follow up",
+    "followup",
+    "respond",
+    "reply needed",
+    "awaiting your",
+    "your input",
+    "by end of day",
+    "eod",
+    "by friday",
+    "by monday",
+];
+
+fn process_email_with_heuristics(
+    email: &Email,
+    input: &EmailMatchInput,
+) -> Option<EmailProcessingResult> {
+    let subject_lower = input.subject.to_lowercase();
+    let body_lower = input
+        .body_text
+        .as_ref()
+        .map(|b| b.to_lowercase())
+        .unwrap_or_default();
+    let content = format!("{} {}", subject_lower, body_lower);
+
+    let matched_keywords: Vec<String> = ACTIONABLE_KEYWORDS
+        .iter()
+        .filter(|kw| content.contains(*kw))
+        .map(|s| s.to_string())
+        .collect();
+
+    if matched_keywords.is_empty() {
+        return None;
+    }
+
+    let subject_matches = ACTIONABLE_KEYWORDS
+        .iter()
+        .filter(|kw| subject_lower.contains(*kw))
+        .count();
+    let confidence = match (subject_matches, matched_keywords.len()) {
+        (s, _) if s >= 2 => 0.9,
+        (1, t) if t >= 2 => 0.8,
+        (1, _) => 0.7,
+        (0, t) if t >= 3 => 0.6,
+        (0, t) if t >= 2 => 0.5,
+        _ => 0.4,
+    };
+
+    let proposed_action = build_todo_action_from_rule(&None, input);
+
+    let reasoning = format!(
+        "Detected actionable keywords in email: {}",
+        matched_keywords.join(", ")
+    );
+
+    let reasoning_details = ReasoningDetails {
+        matched_keywords: Some(matched_keywords),
+        detected_deadline: None,
+        sender_frequency: None,
+        thread_length: None,
+        heuristic_score: Some(confidence),
+        llm_analysis: None,
+    };
+
+    Some(EmailProcessingResult {
+        email_id: email.id,
+        gmail_id: email.gmail_id.clone(),
+        decision_type: DecisionType::CreateTodo.as_str().to_string(),
+        proposed_action,
+        reasoning,
+        reasoning_details,
+        confidence,
+        matched_rule: None,
+        auto_execute: false,
+    })
+}
+
+#[derive(Debug, Default)]
+pub struct ProcessingStats {
+    pub processed: usize,
+    pub rule_matched: usize,
+    pub heuristic_proposed: usize,
+    pub ignored: usize,
+    pub errors: usize,
+}
+
+#[derive(Debug)]
+enum ProcessedEmailOutcome {
+    RuleMatched,
+    HeuristicProposed,
+    Ignored,
+}
+
+/// Process unprocessed emails, creating decisions and optionally executing them
+pub async fn process_pending_emails(pool: &DbPool, limit: i64) -> anyhow::Result<ProcessingStats> {
+    let mut conn = pool.get().await?;
+
+    // Get active rules once for all emails
+    let rules = db::agent_rules::list_active_for_source(&mut conn, "email").await?;
+    tracing::debug!("Loaded {} active email rules", rules.len());
+
+    // Get unprocessed emails
+    let emails = db::emails::list_unprocessed(&mut conn, limit).await?;
+    tracing::info!("Processing {} unprocessed emails", emails.len());
+
+    let mut stats = ProcessingStats::default();
+
+    for email in emails {
+        match process_single_email(&mut conn, &email, &rules).await {
+            Ok(result) => {
+                stats.processed += 1;
+                match result {
+                    ProcessedEmailOutcome::RuleMatched => stats.rule_matched += 1,
+                    ProcessedEmailOutcome::HeuristicProposed => stats.heuristic_proposed += 1,
+                    ProcessedEmailOutcome::Ignored => stats.ignored += 1,
+                }
+            }
+            Err(e) => {
+                stats.errors += 1;
+                tracing::error!("Failed to process email {}: {}", email.id, e);
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
+fn determine_decision_status(result: &EmailProcessingResult) -> (DecisionStatus, Option<Uuid>) {
+    if result.auto_execute {
+        if let Some(ref rule_match) = result.matched_rule {
+            (DecisionStatus::AutoApproved, Some(rule_match.rule_id))
+        } else {
+            (DecisionStatus::Proposed, None)
+        }
+    } else {
+        (DecisionStatus::Proposed, None)
+    }
+}
+
+async fn create_decision_from_result(
+    conn: &mut diesel_async::AsyncPgConnection,
+    email: &Email,
+    result: &EmailProcessingResult,
+    status: DecisionStatus,
+    applied_rule_id: Option<Uuid>,
+) -> anyhow::Result<Uuid> {
+    let proposed_action_json = serde_json::to_string(&result.proposed_action)?;
+    let reasoning_details_json = serde_json::to_string(&result.reasoning_details)?;
+
+    let decision_id = db::decisions::create_with_status(
+        conn,
+        "email",
+        Some(email.id),
+        Some(&email.gmail_id),
+        &result.decision_type,
+        &proposed_action_json,
+        &result.reasoning,
+        Some(&reasoning_details_json),
+        result.confidence,
+        status.as_str(),
+        applied_rule_id,
+    )
+    .await?;
+
+    tracing::info!(
+        "Created decision {} for email {} (status: {}, action: {})",
+        decision_id,
+        email.gmail_id,
+        status.as_str(),
+        result.decision_type
+    );
+
+    Ok(decision_id)
+}
+
+async fn execute_auto_approved_todo(
+    conn: &mut diesel_async::AsyncPgConnection,
+    email: &Email,
+    decision_id: Uuid,
+    proposed_action: &ProposedTodoAction,
+) -> anyhow::Result<()> {
+    let todo_id = db::decisions::create_todo_from_decision(
+        conn,
+        decision_id,
+        &proposed_action.todo_title,
+        proposed_action.todo_description.as_deref(),
+        "email",
+        Some(&email.gmail_id),
+        proposed_action.due_date,
+        proposed_action.category_id,
+    )
+    .await?;
+
+    db::decisions::update_result_todo(conn, decision_id, todo_id).await?;
+
+    tracing::info!(
+        "Auto-created todo {} from decision {} for email {}",
+        todo_id,
+        decision_id,
+        email.gmail_id
+    );
+
+    Ok(())
+}
+
+async fn process_single_email(
+    conn: &mut diesel_async::AsyncPgConnection,
+    email: &Email,
+    rules: &[AgentRule],
+) -> anyhow::Result<ProcessedEmailOutcome> {
+    let result = process_email_with_rules(email, rules);
+
+    let outcome = match result {
+        Some(processing_result) => {
+            let (status, applied_rule_id) = determine_decision_status(&processing_result);
+
+            let decision_id = create_decision_from_result(
+                conn,
+                email,
+                &processing_result,
+                status,
+                applied_rule_id,
+            )
+            .await?;
+
+            // Update rule match count if a rule matched
+            if let Some(ref rule_match) = processing_result.matched_rule {
+                db::agent_rules::increment_match_count(conn, rule_match.rule_id).await?;
+            }
+
+            // Execute auto-approved create_todo decisions
+            if status == DecisionStatus::AutoApproved
+                && processing_result.decision_type == DecisionType::CreateTodo.as_str()
+            {
+                execute_auto_approved_todo(
+                    conn,
+                    email,
+                    decision_id,
+                    &processing_result.proposed_action,
+                )
+                .await?;
+            }
+
+            if processing_result.matched_rule.is_some() {
+                ProcessedEmailOutcome::RuleMatched
+            } else {
+                ProcessedEmailOutcome::HeuristicProposed
+            }
+        }
+        None => {
+            tracing::debug!(
+                "Email {} not actionable, marking as processed",
+                email.gmail_id
+            );
+            ProcessedEmailOutcome::Ignored
+        }
+    };
+
+    db::emails::mark_processed(conn, email.id).await?;
+
+    Ok(outcome)
+}


### PR DESCRIPTION
## Summary
- Move email polling from separate `email-poller` crate into backend as a tokio background task
- Add Gmail client using `AuthorizedUserAuthenticator` for database-stored OAuth tokens
- Add email processor with rule-based and heuristic email processing
- Add missing DB functions for email insert, mark processed, and decision creation

## Changes
- Add `pollers` module to backend with `email.rs`, `gmail_client.rs`, `processor.rs`
- Update `main.rs` to spawn polling task on startup
- Add `NewEmail` model for email insertion
- Add `create_with_status`, `create_todo_from_decision`, `update_result_todo` to decisions module
- Add `update_sync_error` to email_accounts module
- Add `insert`, `mark_processed` to emails module
- Add `list_active_for_source` to agent_rules module

## Test plan
- [x] `cargo check -p backend` passes
- [x] `cargo clippy -p backend` passes
- [x] `cargo fmt` passes