### PR TITLE
Use changeset structs for batch updates

### DIFF
--- a/crates/backend/src/models.rs
+++ b/crates/backend/src/models.rs
@@ -70,3 +70,32 @@ pub struct NewEmail {
     pub has_attachments: bool,
     pub received_at: DateTime<Utc>,
 }
+
+/// Changeset for updating todos in a single query
+#[derive(Debug, Clone, Default, AsChangeset)]
+#[diesel(table_name = crate::schema::todos)]
+pub struct TodoChanges {
+    pub title: Option<String>,
+    pub description: Option<Option<String>>,
+    pub completed: Option<bool>,
+    pub due_date: Option<Option<DateTime<Utc>>>,
+    pub link: Option<Option<String>>,
+    pub category_id: Option<Option<Uuid>>,
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// Changeset for updating agent rules in a single query
+#[derive(Debug, Clone, Default, AsChangeset)]
+#[diesel(table_name = crate::schema::agent_rules)]
+pub struct AgentRuleChanges {
+    pub name: Option<String>,
+    pub description: Option<Option<String>>,
+    pub source_type: Option<String>,
+    pub rule_type: Option<String>,
+    pub conditions: Option<String>,
+    pub action: Option<String>,
+    pub action_params: Option<Option<String>>,
+    pub priority: Option<i32>,
+    pub is_active: Option<bool>,
+    pub updated_at: Option<DateTime<Utc>>,
+}


### PR DESCRIPTION
## Summary
Fixes #54

Replaces multiple sequential UPDATE queries with single batch updates using Diesel's `AsChangeset` derive macro.

## Changes
- Add `TodoChanges` and `AgentRuleChanges` structs in `models.rs`
- Refactor `todos::update` to use `TodoChanges` changeset (reduces 7 queries to 1)
- Refactor `agent_rules::update` to use `AgentRuleChanges` changeset (reduces 10 queries to 1)

## Before
```rust
// 7+ separate UPDATE queries!
if let Some(t) = title_val {
    diesel::update(todos.filter(id.eq(todo_id)))
        .set(title.eq(t))
        .execute(conn).await?;
}
// ... repeated for each field
```

## After
```rust
// Single UPDATE query
let changes = TodoChanges {
    title: title_val.map(|s| s.to_string()),
    // ... all fields
    updated_at: Some(Utc::now()),
};
diesel::update(todos.filter(id.eq(todo_id)))
    .set(&changes)
    .get_result::<Todo>(conn)
    .await?;
```

## Impact
- Reduces database round-trips from N to 1 per update
- ~40 lines of code simplified
- Better performance for updates

## Test plan
- [x] `cargo check -p backend` passes
- [x] `cargo clippy -p backend` passes