### PR TITLE
Add typed JSON wrapper for TEXT columns

### DIFF
--- a/crates/shared-types/src/json_wrapper.rs
+++ b/crates/shared-types/src/json_wrapper.rs
@@ -1,0 +1,168 @@
+//! Typed JSON wrapper for Diesel TEXT columns.
+//!
+//! This module provides a generic wrapper type that automatically handles
+//! serialization/deserialization of typed data stored as JSON strings in
+//! TEXT columns.
+
+use diesel::deserialize::{FromSql, FromSqlRow};
+use diesel::expression::AsExpression;
+use diesel::pg::{Pg, PgValue};
+use diesel::serialize::{IsNull, Output, ToSql};
+use diesel::sql_types::Text;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::fmt;
+use std::io::Write;
+use std::ops::{Deref, DerefMut};
+
+/// A wrapper that stores typed data as JSON in TEXT columns.
+///
+/// This wrapper automatically serializes to/from JSON when reading/writing
+/// to the database, providing type safety at the database boundary.
+///
+/// # Example
+///
+/// ```ignore
+/// use shared_types::{JsonWrapper, RuleConditions};
+///
+/// // In a database model:
+/// pub struct AgentRule {
+///     pub conditions: JsonWrapper<RuleConditions>,
+/// }
+///
+/// // The wrapper transparently serializes/deserializes
+/// let conditions = JsonWrapper::new(RuleConditions { ... });
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, AsExpression, FromSqlRow)]
+#[serde(transparent)]
+#[diesel(sql_type = Text)]
+pub struct JsonWrapper<T>(pub T);
+
+impl<T> JsonWrapper<T> {
+    /// Create a new wrapper around a value.
+    pub fn new(value: T) -> Self {
+        JsonWrapper(value)
+    }
+
+    /// Unwrap and return the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T: Default> Default for JsonWrapper<T> {
+    fn default() -> Self {
+        JsonWrapper(T::default())
+    }
+}
+
+impl<T> Deref for JsonWrapper<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for JsonWrapper<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> From<T> for JsonWrapper<T> {
+    fn from(value: T) -> Self {
+        JsonWrapper(value)
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for JsonWrapper<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// Diesel integration for JsonWrapper
+
+impl<T> FromSql<Text, Pg> for JsonWrapper<T>
+where
+    T: DeserializeOwned,
+{
+    fn from_sql(bytes: PgValue<'_>) -> diesel::deserialize::Result<Self> {
+        let s = <String as FromSql<Text, Pg>>::from_sql(bytes)?;
+        let value: T = serde_json::from_str(&s)
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+        Ok(JsonWrapper(value))
+    }
+}
+
+impl<T> ToSql<Text, Pg> for JsonWrapper<T>
+where
+    T: Serialize + fmt::Debug,
+{
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> diesel::serialize::Result {
+        let s = serde_json::to_string(&self.0)?;
+        out.write_all(s.as_bytes())?;
+        Ok(IsNull::No)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct TestData {
+        name: String,
+        value: i32,
+    }
+
+    #[test]
+    fn test_wrapper_creation() {
+        let data = TestData {
+            name: "test".to_string(),
+            value: 42,
+        };
+        let wrapped = JsonWrapper::new(data.clone());
+        assert_eq!(wrapped.0, data);
+    }
+
+    #[test]
+    fn test_wrapper_deref() {
+        let data = TestData {
+            name: "test".to_string(),
+            value: 42,
+        };
+        let wrapped = JsonWrapper::new(data);
+        assert_eq!(wrapped.name, "test");
+        assert_eq!(wrapped.value, 42);
+    }
+
+    #[test]
+    fn test_wrapper_into_inner() {
+        let data = TestData {
+            name: "test".to_string(),
+            value: 42,
+        };
+        let wrapped = JsonWrapper::new(data.clone());
+        let unwrapped = wrapped.into_inner();
+        assert_eq!(unwrapped, data);
+    }
+
+    #[test]
+    fn test_wrapper_serde() {
+        let data = TestData {
+            name: "test".to_string(),
+            value: 42,
+        };
+        let wrapped = JsonWrapper::new(data);
+
+        // Serialize
+        let json = serde_json::to_string(&wrapped).unwrap();
+        assert_eq!(json, r#"{"name":"test","value":42}"#);
+
+        // Deserialize
+        let parsed: JsonWrapper<TestData> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.0.name, "test");
+        assert_eq!(parsed.0.value, 42);
+    }
+}

--- a/crates/shared-types/src/lib.rs
+++ b/crates/shared-types/src/lib.rs
@@ -4,6 +4,42 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use uuid::Uuid;
 
+#[cfg(feature = "diesel")]
+mod json_wrapper;
+#[cfg(feature = "diesel")]
+pub use json_wrapper::JsonWrapper;
+
+// ============================================================================
+// Typed JSON Field Aliases
+// ============================================================================
+//
+// These type aliases provide type-safe access to JSON fields stored in TEXT
+// columns. Use these in database models instead of raw String fields.
+//
+// Example usage in a Queryable struct:
+//   pub conditions: TypedRuleConditions,
+//   pub action_params: Option<TypedRuleActionParams>,
+
+/// Typed wrapper for rule conditions JSON field
+#[cfg(feature = "diesel")]
+pub type TypedRuleConditions = JsonWrapper<RuleConditions>;
+
+/// Typed wrapper for rule action params JSON field
+#[cfg(feature = "diesel")]
+pub type TypedRuleActionParams = JsonWrapper<RuleActionParams>;
+
+/// Typed wrapper for proposed todo action JSON field
+#[cfg(feature = "diesel")]
+pub type TypedProposedAction = JsonWrapper<ProposedTodoAction>;
+
+/// Typed wrapper for reasoning details JSON field
+#[cfg(feature = "diesel")]
+pub type TypedReasoningDetails = JsonWrapper<ReasoningDetails>;
+
+/// Typed wrapper for calendar attendees JSON field
+#[cfg(feature = "diesel")]
+pub type TypedCalendarAttendees = JsonWrapper<Vec<CalendarAttendee>>;
+
 // ============================================================================
 // Regex Cache for Rule Matching
 // ============================================================================


### PR DESCRIPTION
## Summary
- Adds `JsonWrapper<T>` generic type that auto-serializes/deserializes typed data to JSON strings in TEXT columns
- Provides diesel `FromSql` and `ToSql` implementations for seamless database integration
- Adds typed aliases: `TypedRuleConditions`, `TypedRuleActionParams`, `TypedProposedAction`, `TypedReasoningDetails`, `TypedCalendarAttendees`

Closes #58

## Usage Example
```rust
// Instead of:
pub conditions: String, // JSON string manually parsed

// Use:
pub conditions: TypedRuleConditions, // Automatically serialized/deserialized
```

## Test plan
- [ ] Verify `JsonWrapper` serde tests pass
- [ ] Verify workspace compiles with `cargo check --workspace`
- [ ] Follow-up PR can migrate existing models to use the typed wrappers