### PR TITLE
Consolidate calendar poller into backend

### DIFF
--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -26,9 +26,15 @@ async fn main() -> anyhow::Result<()> {
     let pool = db::establish_connection_pool()?;
 
     // Start email polling background task
-    let poll_pool = pool.clone();
+    let email_poll_pool = pool.clone();
     tokio::spawn(async move {
-        pollers::start_email_polling_task(poll_pool).await;
+        pollers::start_email_polling_task(email_poll_pool).await;
+    });
+
+    // Start calendar polling background task (stub - not yet implemented)
+    let calendar_poll_pool = pool.clone();
+    tokio::spawn(async move {
+        pollers::start_calendar_polling_task(calendar_poll_pool).await;
     });
 
     let app = Router::new()

--- a/crates/backend/src/pollers/calendar.rs
+++ b/crates/backend/src/pollers/calendar.rs
@@ -1,0 +1,73 @@
+//! Calendar polling background task (placeholder).
+//!
+//! This module provides the structure for calendar polling but is currently
+//! a stub. The actual Google Calendar API integration is not yet implemented.
+//!
+//! TODO: Implement Google Calendar API integration similar to gmail_client.rs
+//!
+//! When implemented, this should:
+//! 1. Use the same OAuth2 flow as Gmail
+//! 2. Fetch upcoming calendar events
+//! 3. Create AgentDecisions for events that might need todo items
+//! 4. Store calendar events in the calendar_events table
+
+use crate::db::DbPool;
+use std::time::Duration;
+
+/// Configuration for the calendar polling task
+#[derive(Debug, Clone)]
+pub struct CalendarPollerConfig {
+    /// How often to poll for calendar events (default: 15 minutes)
+    pub poll_interval: Duration,
+    /// How many days ahead to look for events
+    pub days_ahead: u32,
+}
+
+impl Default for CalendarPollerConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: Duration::from_secs(900), // 15 minutes
+            days_ahead: 7,
+        }
+    }
+}
+
+impl CalendarPollerConfig {
+    /// Load configuration from environment variables
+    pub fn from_env() -> Self {
+        let poll_interval_secs = std::env::var("CALENDAR_POLL_INTERVAL_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(900);
+
+        let days_ahead = std::env::var("CALENDAR_DAYS_AHEAD")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(7);
+
+        Self {
+            poll_interval: Duration::from_secs(poll_interval_secs),
+            days_ahead,
+        }
+    }
+}
+
+/// Start the calendar polling background task.
+///
+/// Currently this is a placeholder that logs periodically but does not
+/// actually poll any calendars. The Google Calendar API integration
+/// is not yet implemented.
+pub async fn start_calendar_polling_task(_pool: DbPool) {
+    let config = CalendarPollerConfig::from_env();
+
+    tracing::info!(
+        "Calendar polling task started (interval: {:?}, days ahead: {}) [STUB - not implemented]",
+        config.poll_interval,
+        config.days_ahead
+    );
+
+    loop {
+        tracing::debug!("Calendar poll tick (no-op - integration not implemented)");
+        tokio::time::sleep(config.poll_interval).await;
+    }
+}

--- a/crates/backend/src/pollers/mod.rs
+++ b/crates/backend/src/pollers/mod.rs
@@ -1,10 +1,12 @@
 //! Background polling tasks for email and calendar integration.
 //!
-//! This module consolidates the email-poller functionality into the backend,
+//! This module consolidates polling functionality into the backend,
 //! running as tokio background tasks rather than separate processes.
 
+pub mod calendar;
 pub mod email;
 mod gmail_client;
 mod processor;
 
+pub use calendar::start_calendar_polling_task;
 pub use email::start_email_polling_task;


### PR DESCRIPTION
## Summary
- Adds `calendar.rs` module to backend's pollers with documented stub
- Starts calendar polling background task in main.rs (mirrors email polling)
- Provides architecture foundation for future Google Calendar API integration

Closes #26

## Current State
The calendar poller is a placeholder that:
- Logs startup message with "STUB - not implemented" 
- Runs periodic tick (default 15 min) with no-op
- Documents what needs to be implemented via TODOs

## Future Work
When Google Calendar API is integrated:
1. Create `calendar_client.rs` similar to `gmail_client.rs`
2. Implement OAuth2 flow for Google Calendar
3. Fetch upcoming events and create AgentDecisions
4. Store events in `calendar_events` table

## Test plan
- [ ] Verify `cargo check --package backend` passes
- [ ] Verify backend starts with calendar polling stub
- [ ] Check logs show calendar polling messages at startup