### PR TITLE
Add connection pool helper function (#57)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,7 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "base64 0.22.1",
  "chrono",

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -41,6 +41,7 @@ base64 = "0.22.1"
 regex = "1"
 hyper = { version = "1.8.1", features = ["client"] }
 hyper-util = { version = "0.1.18", features = ["client-legacy"] }
+async-trait = "0.1.89"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -18,13 +18,13 @@ use uuid::Uuid;
 
 use crate::db::{
     agent_rules, calendar_accounts, calendar_events, categories, chat_messages, decisions,
-    email_accounts, emails, todos, DbPool,
+    email_accounts, emails, get_conn, todos, DbPool,
 };
 use crate::error::{ApiError, ApiResult};
 
 // Todo handlers
 pub async fn list_todos(State(pool): State<DbPool>) -> ApiResult<Json<Vec<Todo>>> {
-    let mut conn = pool.get().await?;
+    let mut conn = get_conn(&pool).await?;
     let items = todos::list_all(&mut conn).await?;
     Ok(Json(items))
 }
@@ -33,7 +33,7 @@ pub async fn create_todo(
     State(pool): State<DbPool>,
     Json(payload): Json<CreateTodoRequest>,
 ) -> ApiResult<Json<Todo>> {
-    let mut conn = pool.get().await?;
+    let mut conn = get_conn(&pool).await?;
     let todo = todos::create(
         &mut conn,
         &payload.title,
@@ -51,7 +51,7 @@ pub async fn update_todo(
     Path(id): Path<Uuid>,
     Json(payload): Json<UpdateTodoRequest>,
 ) -> ApiResult<Json<Todo>> {
-    let mut conn = pool.get().await?;
+    let mut conn = get_conn(&pool).await?;
     let todo = todos::update(
         &mut conn,
         id,
@@ -70,7 +70,7 @@ pub async fn delete_todo(
     State(pool): State<DbPool>,
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
-    let mut conn = pool.get().await?;
+    let mut conn = get_conn(&pool).await?;
     todos::delete(&mut conn, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -275,7 +275,7 @@ pub async fn gmail_oauth_callback(
 
 // Category handlers
 pub async fn list_categories(State(pool): State<DbPool>) -> ApiResult<Json<Vec<Category>>> {
-    let mut conn = pool.get().await?;
+    let mut conn = get_conn(&pool).await?;
     let items = categories::list_all(&mut conn).await?;
     Ok(Json(items))
 }
@@ -284,7 +284,7 @@ pub async fn create_category(
     State(pool): State<DbPool>,
     Json(payload): Json<CreateCategoryRequest>,
 ) -> ApiResult<Json<Category>> {
-    let mut conn = pool.get().await?;
+    let mut conn = get_conn(&pool).await?;
     let category = categories::create(&mut conn, &payload.name, payload.color.as_deref()).await?;
     Ok(Json(category))
 }
@@ -294,7 +294,7 @@ pub async fn update_category(
     Path(id): Path<Uuid>,
     Json(payload): Json<UpdateCategoryRequest>,
 ) -> ApiResult<Json<Category>> {
-    let mut conn = pool.get().await?;
+    let mut conn = get_conn(&pool).await?;
     let category = categories::update(
         &mut conn,
         id,
@@ -309,7 +309,7 @@ pub async fn delete_category(
     State(pool): State<DbPool>,
     Path(id): Path<Uuid>,
 ) -> ApiResult<StatusCode> {
-    let mut conn = pool.get().await?;
+    let mut conn = get_conn(&pool).await?;
     categories::delete(&mut conn, id).await?;
     Ok(StatusCode::NO_CONTENT)
 }


### PR DESCRIPTION
## Summary
- Add `get_conn(pool)` helper function that wraps pool access with automatic `ApiError` conversion
- Add `DbConn` type alias for connection objects returned from the pool
- Update 8 handlers that use the simple `pool.get().await?` pattern to use the new helper

This provides a single point for:
- Automatic error conversion to `ApiError::ConnectionPool`
- Future metrics/logging hooks
- Connection timeout configuration

Closes #57

## Test plan
- [x] `cargo build -p backend` passes
- [x] `cargo clippy -p backend` passes
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)