### PR TITLE
Extract decision service layer

### DIFF
--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -10,9 +10,8 @@ use shared_types::{
     CalendarEventResponse, Category, ChatHistoryQuery, ChatIntent, ChatMessageResponse,
     ChatResponse, ConnectEmailAccountRequest, CreateAgentDecisionRequest, CreateAgentRuleRequest,
     CreateCategoryRequest, CreateTodoRequest, DecisionStats, EmailAccountResponse, EmailListQuery,
-    EmailResponse, ProposedTodoAction, RejectDecisionRequest, RuleListQuery,
-    SendChatMessageRequest, SuggestedAction, Todo, UpdateAgentRuleRequest, UpdateCategoryRequest,
-    UpdateTodoRequest,
+    EmailResponse, RejectDecisionRequest, RuleListQuery, SendChatMessageRequest, SuggestedAction,
+    Todo, UpdateAgentRuleRequest, UpdateCategoryRequest, UpdateTodoRequest,
 };
 use uuid::Uuid;
 
@@ -21,6 +20,7 @@ use crate::db::{
     email_accounts, emails, get_conn, todos, DbPool,
 };
 use crate::error::{ApiError, ApiResult};
+use crate::services::DecisionService;
 
 // Todo handlers
 pub async fn list_todos(State(pool): State<DbPool>) -> ApiResult<Json<Vec<Todo>>> {
@@ -460,45 +460,8 @@ pub async fn approve_decision(
     Json(payload): Json<ApproveDecisionRequest>,
 ) -> ApiResult<Json<AgentDecisionResponse>> {
     let mut conn = pool.get().await?;
-
-    // Get the decision first
-    let decision = decisions::get_by_id(&mut conn, id).await?;
-
-    // If decision type is create_todo, create the todo
-    let todo_id = if decision.decision_type == "create_todo" {
-        // Use modifications if provided, otherwise use proposed_action
-        let action: ProposedTodoAction = if let Some(mods) = payload.modifications {
-            mods
-        } else {
-            serde_json::from_str(&decision.proposed_action)?
-        };
-
-        let todo = todos::create(
-            &mut conn,
-            &action.todo_title,
-            action.todo_description.as_deref(),
-            action.due_date,
-            None, // link
-            action.category_id,
-        )
-        .await?;
-
-        Some(todo.id)
-    } else {
-        None
-    };
-
-    // Update the decision status
-    let updated = decisions::approve(&mut conn, id, todo_id).await?;
-
-    // Mark as executed since we've already created the todo
-    let final_decision = if todo_id.is_some() {
-        decisions::mark_executed(&mut conn, id).await?
-    } else {
-        updated
-    };
-
-    Ok(Json(final_decision.into()))
+    let result = DecisionService::approve(&mut conn, id, payload.modifications).await?;
+    Ok(Json(result.decision.into()))
 }
 
 pub async fn reject_decision(
@@ -507,7 +470,7 @@ pub async fn reject_decision(
     Json(payload): Json<RejectDecisionRequest>,
 ) -> ApiResult<Json<AgentDecisionResponse>> {
     let mut conn = pool.get().await?;
-    let decision = decisions::reject(&mut conn, id, payload.feedback.as_deref()).await?;
+    let decision = DecisionService::reject(&mut conn, id, payload.feedback.as_deref()).await?;
     Ok(Json(decision.into()))
 }
 
@@ -521,101 +484,40 @@ pub async fn batch_approve_decisions(
     State(pool): State<DbPool>,
     Json(payload): Json<BatchApproveDecisionsRequest>,
 ) -> ApiResult<Json<BatchOperationResponse>> {
-    let mut conn = pool.get().await?;
-
-    let mut successful = Vec::new();
-    let mut failed = Vec::new();
-
-    for decision_id in payload.decision_ids {
-        // Get the decision
-        let decision = match decisions::get_by_id(&mut conn, decision_id).await {
-            Ok(d) => d,
-            Err(e) => {
-                failed.push(BatchOperationFailure {
-                    id: decision_id,
-                    error: format!("Decision not found: {}", e),
-                });
-                continue;
-            }
-        };
-
-        // Create todo if decision type is create_todo
-        let todo_id = if decision.decision_type == "create_todo" {
-            let action: ProposedTodoAction = match serde_json::from_str(&decision.proposed_action) {
-                Ok(a) => a,
-                Err(e) => {
-                    failed.push(BatchOperationFailure {
-                        id: decision_id,
-                        error: format!("Failed to parse proposed_action: {}", e),
-                    });
-                    continue;
-                }
-            };
-
-            match todos::create(
-                &mut conn,
-                &action.todo_title,
-                action.todo_description.as_deref(),
-                action.due_date,
-                None,
-                action.category_id,
-            )
-            .await
-            {
-                Ok(todo) => Some(todo.id),
-                Err(e) => {
-                    failed.push(BatchOperationFailure {
-                        id: decision_id,
-                        error: format!("Failed to create todo: {}", e),
-                    });
-                    continue;
-                }
-            }
-        } else {
-            None
-        };
-
-        // Approve and mark as executed
-        if let Err(e) = decisions::approve(&mut conn, decision_id, todo_id).await {
-            failed.push(BatchOperationFailure {
-                id: decision_id,
-                error: format!("Failed to approve: {}", e),
-            });
-            continue;
-        }
-
-        if todo_id.is_some() {
-            if let Err(e) = decisions::mark_executed(&mut conn, decision_id).await {
-                tracing::warn!("Failed to mark decision as executed: {}", e);
-            }
-        }
-
-        successful.push(decision_id);
-    }
-
-    Ok(Json(BatchOperationResponse { successful, failed }))
+    let result = DecisionService::batch_approve(&pool, payload.decision_ids).await?;
+    let failed = result
+        .failed
+        .into_iter()
+        .map(|f| BatchOperationFailure {
+            id: f.id,
+            error: f.error,
+        })
+        .collect();
+    Ok(Json(BatchOperationResponse {
+        successful: result.successful,
+        failed,
+    }))
 }
 
 pub async fn batch_reject_decisions(
     State(pool): State<DbPool>,
     Json(payload): Json<BatchRejectDecisionsRequest>,
 ) -> ApiResult<Json<BatchOperationResponse>> {
-    let mut conn = pool.get().await?;
-
-    let mut successful = Vec::new();
-    let mut failed = Vec::new();
-
-    for decision_id in payload.decision_ids {
-        match decisions::reject(&mut conn, decision_id, payload.feedback.as_deref()).await {
-            Ok(_) => successful.push(decision_id),
-            Err(e) => failed.push(BatchOperationFailure {
-                id: decision_id,
-                error: format!("Failed to reject: {}", e),
-            }),
-        }
-    }
-
-    Ok(Json(BatchOperationResponse { successful, failed }))
+    let result =
+        DecisionService::batch_reject(&pool, payload.decision_ids, payload.feedback.as_deref())
+            .await?;
+    let failed = result
+        .failed
+        .into_iter()
+        .map(|f| BatchOperationFailure {
+            id: f.id,
+            error: f.error,
+        })
+        .collect();
+    Ok(Json(BatchOperationResponse {
+        successful: result.successful,
+        failed,
+    }))
 }
 
 // Agent rules handlers

--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -15,6 +15,7 @@ mod handlers;
 mod models;
 mod pollers;
 mod schema;
+mod services;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/crates/backend/src/services/decision.rs
+++ b/crates/backend/src/services/decision.rs
@@ -1,0 +1,148 @@
+//! Decision approval and execution service.
+//!
+//! This module extracts business logic from HTTP handlers for better
+//! testability and reuse. It provides a centralized place for decision
+//! approval/rejection logic.
+
+use crate::db::{decisions, todos, DbPool};
+use anyhow::{Context, Result};
+use diesel_async::AsyncPgConnection;
+use shared_types::{AgentDecision, ProposedTodoAction};
+use uuid::Uuid;
+
+/// Result of approving a decision
+pub struct ApprovalResult {
+    pub decision: AgentDecision,
+    #[allow(dead_code)]
+    pub created_todo_id: Option<Uuid>,
+}
+
+/// Result of a batch operation
+pub struct BatchResult {
+    pub successful: Vec<Uuid>,
+    pub failed: Vec<BatchFailure>,
+}
+
+pub struct BatchFailure {
+    pub id: Uuid,
+    pub error: String,
+}
+
+/// Service for decision-related business logic
+pub struct DecisionService;
+
+impl DecisionService {
+    /// Approve a decision, optionally with modifications to the proposed action
+    pub async fn approve(
+        conn: &mut AsyncPgConnection,
+        decision_id: Uuid,
+        modifications: Option<ProposedTodoAction>,
+    ) -> Result<ApprovalResult> {
+        // Get the decision
+        let decision = decisions::get_by_id(conn, decision_id)
+            .await
+            .context("Decision not found")?;
+
+        // Create todo if decision type is create_todo
+        let created_todo_id = if decision.decision_type == "create_todo" {
+            let action = Self::get_action(&decision, modifications)?;
+            let todo = todos::create(
+                conn,
+                &action.todo_title,
+                action.todo_description.as_deref(),
+                action.due_date,
+                None,
+                action.category_id,
+            )
+            .await
+            .context("Failed to create todo")?;
+            Some(todo.id)
+        } else {
+            None
+        };
+
+        // Update decision status
+        decisions::approve(conn, decision_id, created_todo_id)
+            .await
+            .context("Failed to approve decision")?;
+
+        // Mark as executed if todo was created
+        let final_decision = if created_todo_id.is_some() {
+            decisions::mark_executed(conn, decision_id)
+                .await
+                .context("Failed to mark as executed")?
+        } else {
+            decisions::get_by_id(conn, decision_id).await?
+        };
+
+        Ok(ApprovalResult {
+            decision: final_decision,
+            created_todo_id,
+        })
+    }
+
+    /// Reject a decision with optional feedback
+    pub async fn reject(
+        conn: &mut AsyncPgConnection,
+        decision_id: Uuid,
+        feedback: Option<&str>,
+    ) -> Result<AgentDecision> {
+        decisions::reject(conn, decision_id, feedback)
+            .await
+            .context("Failed to reject decision")
+    }
+
+    /// Approve multiple decisions in batch
+    pub async fn batch_approve(pool: &DbPool, decision_ids: Vec<Uuid>) -> Result<BatchResult> {
+        let mut conn = pool.get().await.context("Failed to get connection")?;
+        let mut successful = Vec::new();
+        let mut failed = Vec::new();
+
+        for decision_id in decision_ids {
+            match Self::approve(&mut conn, decision_id, None).await {
+                Ok(result) => successful.push(result.decision.id),
+                Err(e) => failed.push(BatchFailure {
+                    id: decision_id,
+                    error: e.to_string(),
+                }),
+            }
+        }
+
+        Ok(BatchResult { successful, failed })
+    }
+
+    /// Reject multiple decisions in batch
+    pub async fn batch_reject(
+        pool: &DbPool,
+        decision_ids: Vec<Uuid>,
+        feedback: Option<&str>,
+    ) -> Result<BatchResult> {
+        let mut conn = pool.get().await.context("Failed to get connection")?;
+        let mut successful = Vec::new();
+        let mut failed = Vec::new();
+
+        for decision_id in decision_ids {
+            match Self::reject(&mut conn, decision_id, feedback).await {
+                Ok(decision) => successful.push(decision.id),
+                Err(e) => failed.push(BatchFailure {
+                    id: decision_id,
+                    error: e.to_string(),
+                }),
+            }
+        }
+
+        Ok(BatchResult { successful, failed })
+    }
+
+    /// Extract action from decision, using modifications if provided
+    fn get_action(
+        decision: &AgentDecision,
+        modifications: Option<ProposedTodoAction>,
+    ) -> Result<ProposedTodoAction> {
+        match modifications {
+            Some(action) => Ok(action),
+            None => serde_json::from_str(&decision.proposed_action)
+                .context("Failed to parse proposed_action"),
+        }
+    }
+}

--- a/crates/backend/src/services/mod.rs
+++ b/crates/backend/src/services/mod.rs
@@ -1,0 +1,5 @@
+//! Business logic services separated from HTTP handling.
+
+pub mod decision;
+
+pub use decision::DecisionService;


### PR DESCRIPTION
## Summary
- Creates `DecisionService` in `crates/backend/src/services/` to encapsulate decision approval/rejection logic
- Moves business logic out of HTTP handlers for better testability and reuse
- Refactors `approve_decision`, `reject_decision`, `batch_approve_decisions`, and `batch_reject_decisions` handlers to use the new service

Closes #56

## Test plan
- [ ] Verify decision approval creates todos correctly
- [ ] Verify decision rejection with feedback works
- [ ] Verify batch approve/reject operations work
- [ ] Check compilation passes with `cargo check --workspace`