### PR TITLE
Fix rustls CryptoProvider panic on startup

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 reqwest = { version = "0.12.24", features = ["json"] }
 urlencoding = "2.1.3"
 tokio-postgres-rustls = "0.13.0"
-rustls = "0.23.35"
+rustls = { version = "0.23.35", default-features = false, features = ["ring", "std", "tls12"] }
 webpki-roots = "1.0.4"
 futures = "0.3.31"
 tokio-postgres = "0.7.15"

--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -31,6 +31,11 @@ pub struct AppState {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Install rustls crypto provider before any TLS operations
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     tracing_subscriber::fmt::init();
 
     dotenvy::dotenv().ok();


### PR DESCRIPTION
## Summary
- Install ring crypto provider explicitly at startup before any TLS operations
- Configure rustls with explicit ring feature to avoid auto-detection issues

Fixes #76

## Root Cause
rustls 0.23+ requires explicit crypto provider selection. The email polling background task was panicking because it tried to use TLS before a crypto provider was installed.

## Test plan
- [ ] Build and deploy
- [ ] Verify email polling no longer crashes
- [ ] Verify API endpoints return data instead of 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)