### PR TITLE
Add OAuth account status display to header

### DIFF
--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -1,10 +1,12 @@
+use chrono::{DateTime, Utc};
 use gloo_net::http::Request;
+use serde::Deserialize;
 use shared_types::{
     AgentDecisionResponse, ApproveDecisionRequest, AuthUserResponse, BatchApproveDecisionsRequest,
     BatchRejectDecisionsRequest, CalendarEventResponse, Category, ChatMessageResponse,
-    ChatResponse, CreateTodoRequest, DecisionStats, EmailResponse, LoginInitResponse,
-    ProposedTodoAction, RejectDecisionRequest, SendChatMessageRequest, SuggestedAction, Todo,
-    UpdateTodoRequest,
+    ChatResponse, CreateTodoRequest, DecisionStats, EmailAccountResponse, EmailResponse,
+    LoginInitResponse, ProposedTodoAction, RejectDecisionRequest, SendChatMessageRequest,
+    SuggestedAction, Todo, UpdateTodoRequest,
 };
 use uuid::Uuid;
 use web_sys::{Element, HtmlInputElement};
@@ -23,6 +25,22 @@ pub enum AuthState {
     Authenticated { email: String, name: Option<String> },
     /// User is not authenticated
     Unauthenticated,
+}
+
+// ============================================================================
+// OAuth Account Types (for header display)
+// ============================================================================
+
+/// Calendar account response (mirrors backend CalendarAccountResponse)
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct CalendarAccountResponse {
+    pub id: Uuid,
+    pub account_name: String,
+    pub calendar_id: String,
+    pub email_address: Option<String>,
+    pub sync_status: String,
+    pub last_synced: Option<DateTime<Utc>>,
+    pub is_active: bool,
 }
 
 // ============================================================================
@@ -140,6 +158,191 @@ pub fn app_context_provider(props: &AppContextProviderProps) -> Html {
         <ContextProvider<AppContext> context={context}>
             { props.children.clone() }
         </ContextProvider<AppContext>>
+    }
+}
+
+// ============================================================================
+// Account Status Component - Shows OAuth account status in header
+// ============================================================================
+
+#[function_component(AccountStatus)]
+fn account_status() -> Html {
+    let email_accounts = use_state(Vec::<EmailAccountResponse>::new);
+    let calendar_accounts = use_state(Vec::<CalendarAccountResponse>::new);
+    let expanded = use_state(|| false);
+
+    // Fetch accounts on mount
+    {
+        let email_accounts = email_accounts.clone();
+        let calendar_accounts = calendar_accounts.clone();
+        use_effect_with((), move |_| {
+            let email_accounts = email_accounts.clone();
+            let calendar_accounts = calendar_accounts.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                // Fetch email accounts
+                if let Ok(response) = Request::get("/api/email-accounts").send().await {
+                    if response.ok() {
+                        if let Ok(accounts) = response.json::<Vec<EmailAccountResponse>>().await {
+                            email_accounts.set(accounts);
+                        }
+                    }
+                }
+                // Fetch calendar accounts
+                if let Ok(response) = Request::get("/api/calendar-accounts").send().await {
+                    if response.ok() {
+                        if let Ok(accounts) = response.json::<Vec<CalendarAccountResponse>>().await
+                        {
+                            calendar_accounts.set(accounts);
+                        }
+                    }
+                }
+            });
+            || ()
+        });
+    }
+
+    let toggle_expanded = {
+        let expanded = expanded.clone();
+        Callback::from(move |_| expanded.set(!*expanded))
+    };
+
+    // Helper to get status indicator class
+    fn status_class(status: &str, is_active: bool) -> &'static str {
+        if !is_active {
+            "status-inactive"
+        } else {
+            match status {
+                "success" => "status-ok",
+                "syncing" | "pending" => "status-syncing",
+                "auth_required" => "status-auth-required",
+                "failed" => "status-error",
+                _ => "status-unknown",
+            }
+        }
+    }
+
+    // Count accounts by status
+    let email_ok = email_accounts
+        .iter()
+        .filter(|a| a.is_active && a.sync_status == "success")
+        .count();
+    let email_needs_auth = email_accounts
+        .iter()
+        .filter(|a| a.sync_status == "auth_required")
+        .count();
+    let calendar_ok = calendar_accounts
+        .iter()
+        .filter(|a| a.is_active && a.sync_status == "success")
+        .count();
+    let calendar_needs_auth = calendar_accounts
+        .iter()
+        .filter(|a| a.sync_status == "auth_required")
+        .count();
+
+    let total_accounts = email_accounts.len() + calendar_accounts.len();
+    let needs_attention = email_needs_auth + calendar_needs_auth;
+
+    html! {
+        <div class="account-status-container">
+            <button class="account-status-btn" onclick={toggle_expanded.clone()}>
+                <span class="account-status-icon">{"@"}</span>
+                <span class="account-status-count">{total_accounts}</span>
+                {if needs_attention > 0 {
+                    html! { <span class="account-status-alert">{needs_attention}</span> }
+                } else {
+                    html! {}
+                }}
+            </button>
+
+            {if *expanded {
+                let email_list = (*email_accounts).clone();
+                let calendar_list = (*calendar_accounts).clone();
+                html! {
+                    <div class="account-status-dropdown">
+                        <div class="account-section">
+                            <div class="account-section-header">
+                                <span>{"Email Accounts"}</span>
+                                <span class="account-section-count">{format!("{}/{} ok", email_ok, email_list.len())}</span>
+                            </div>
+                            {if email_list.is_empty() {
+                                html! { <div class="account-empty">{"No email accounts connected"}</div> }
+                            } else {
+                                email_list.iter().map(|account| {
+                                    let status = status_class(&account.sync_status, account.is_active);
+                                    html! {
+                                        <div key={account.id.to_string()} class={format!("account-item {}", status)}>
+                                            <div class="account-info">
+                                                <span class="account-email">{&account.email_address}</span>
+                                                <span class="account-name">{&account.account_name}</span>
+                                            </div>
+                                            <div class="account-status-indicator">
+                                                <span class={format!("status-dot {}", status)}></span>
+                                                <span class="status-text">{
+                                                    if !account.is_active {
+                                                        "Inactive"
+                                                    } else {
+                                                        match account.sync_status.as_str() {
+                                                            "success" => "OK",
+                                                            "syncing" => "Syncing",
+                                                            "pending" => "Pending",
+                                                            "auth_required" => "Auth Required",
+                                                            "failed" => "Failed",
+                                                            _ => "Unknown",
+                                                        }
+                                                    }
+                                                }</span>
+                                            </div>
+                                        </div>
+                                    }
+                                }).collect::<Html>()
+                            }}
+                        </div>
+
+                        <div class="account-section">
+                            <div class="account-section-header">
+                                <span>{"Calendar Accounts"}</span>
+                                <span class="account-section-count">{format!("{}/{} ok", calendar_ok, calendar_list.len())}</span>
+                            </div>
+                            {if calendar_list.is_empty() {
+                                html! { <div class="account-empty">{"No calendar accounts connected"}</div> }
+                            } else {
+                                calendar_list.iter().map(|account| {
+                                    let status = status_class(&account.sync_status, account.is_active);
+                                    let email_display = account.email_address.clone().unwrap_or_else(|| account.calendar_id.clone());
+                                    html! {
+                                        <div key={account.id.to_string()} class={format!("account-item {}", status)}>
+                                            <div class="account-info">
+                                                <span class="account-email">{email_display}</span>
+                                                <span class="account-name">{&account.account_name}</span>
+                                            </div>
+                                            <div class="account-status-indicator">
+                                                <span class={format!("status-dot {}", status)}></span>
+                                                <span class="status-text">{
+                                                    if !account.is_active {
+                                                        "Inactive"
+                                                    } else {
+                                                        match account.sync_status.as_str() {
+                                                            "success" => "OK",
+                                                            "syncing" => "Syncing",
+                                                            "pending" => "Pending",
+                                                            "auth_required" => "Auth Required",
+                                                            "failed" => "Failed",
+                                                            _ => "Unknown",
+                                                        }
+                                                    }
+                                                }</span>
+                                            </div>
+                                        </div>
+                                    }
+                                }).collect::<Html>()
+                            }}
+                        </div>
+                    </div>
+                }
+            } else {
+                html! {}
+            }}
+        </div>
     }
 }
 
@@ -388,13 +591,16 @@ fn authenticated_app(props: &AuthenticatedAppProps) -> Html {
             <header>
                 <div class="header-top">
                     <h1>{"Agentive Inversion"}</h1>
-                    <div class="user-menu">
-                        <span class="user-email">
-                            {props.name.as_ref().unwrap_or(&props.email)}
-                        </span>
-                        <button class="logout-btn" onclick={Callback::from(move |_| on_logout.emit(()))}>
-                            {"Logout"}
-                        </button>
+                    <div class="header-right">
+                        <AccountStatus />
+                        <div class="user-menu">
+                            <span class="user-email">
+                                {props.name.as_ref().unwrap_or(&props.email)}
+                            </span>
+                            <button class="logout-btn" onclick={Callback::from(move |_| on_logout.emit(()))}>
+                                {"Logout"}
+                            </button>
+                        </div>
                     </div>
                 </div>
                 <nav class="main-nav">

--- a/crates/frontend/styles.css
+++ b/crates/frontend/styles.css
@@ -1656,6 +1656,12 @@ main {
     margin-bottom: 16px;
 }
 
+.header-right {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
 .user-menu {
     display: flex;
     align-items: center;
@@ -1684,6 +1690,32 @@ main {
     border-color: #95a5a6;
 }
 
+/* ============================================================================
+   Account Status (OAuth) Styles
+   ============================================================================ */
+
+.account-status-container {
+    position: relative;
+}
+
+.account-status-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    background-color: #f9f9f9;
+    border: 1px solid #ddd;
+    border-radius: 20px;
+    cursor: pointer;
+    font-size: 13px;
+    transition: all 0.2s;
+}
+
+.account-status-btn:hover {
+    background-color: #ecf0f1;
+    border-color: #bdc3c7;
+}
+
 /* Responsive adjustments for login */
 @media (max-width: 480px) {
     .login-card {
@@ -1704,4 +1736,174 @@ main {
         width: 100%;
         justify-content: space-between;
     }
+}
+
+.account-status-icon {
+    font-weight: 600;
+    color: #3498db;
+}
+
+.account-status-count {
+    color: #7f8c8d;
+}
+
+.account-status-alert {
+    background-color: #e74c3c;
+    color: white;
+    font-size: 10px;
+    padding: 1px 5px;
+    border-radius: 10px;
+    font-weight: 600;
+}
+
+.account-status-dropdown {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 8px;
+    width: 320px;
+    background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    z-index: 100;
+    overflow: hidden;
+}
+
+.account-section {
+    padding: 12px;
+    border-bottom: 1px solid #ecf0f1;
+}
+
+.account-section:last-child {
+    border-bottom: none;
+}
+
+.account-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+    font-size: 12px;
+    font-weight: 600;
+    color: #7f8c8d;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.account-section-count {
+    font-weight: normal;
+    font-size: 11px;
+}
+
+.account-empty {
+    font-size: 12px;
+    color: #95a5a6;
+    padding: 8px 0;
+    font-style: italic;
+}
+
+.account-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 10px;
+    margin: 4px 0;
+    background-color: #f9f9f9;
+    border-radius: 4px;
+    border-left: 3px solid #bdc3c7;
+}
+
+.account-item.status-ok {
+    border-left-color: #27ae60;
+}
+
+.account-item.status-syncing {
+    border-left-color: #f39c12;
+}
+
+.account-item.status-auth-required {
+    border-left-color: #e74c3c;
+    background-color: #fef5f5;
+}
+
+.account-item.status-error {
+    border-left-color: #e74c3c;
+}
+
+.account-item.status-inactive {
+    border-left-color: #bdc3c7;
+    opacity: 0.6;
+}
+
+.account-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
+}
+
+.account-email {
+    font-size: 13px;
+    color: #2c3e50;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.account-name {
+    font-size: 11px;
+    color: #95a5a6;
+}
+
+.account-status-indicator {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: #bdc3c7;
+}
+
+.status-dot.status-ok {
+    background-color: #27ae60;
+}
+
+.status-dot.status-syncing {
+    background-color: #f39c12;
+    animation: pulse 1.5s infinite;
+}
+
+.status-dot.status-auth-required {
+    background-color: #e74c3c;
+}
+
+.status-dot.status-error {
+    background-color: #e74c3c;
+}
+
+.status-dot.status-inactive {
+    background-color: #bdc3c7;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+}
+
+.status-text {
+    font-size: 11px;
+    color: #7f8c8d;
+    white-space: nowrap;
+}
+
+.account-item.status-auth-required .status-text {
+    color: #e74c3c;
+    font-weight: 500;
 }


### PR DESCRIPTION
## Summary
- Adds AccountStatus component showing all connected OAuth accounts in the header
- Displays email and calendar accounts with their sync status (OK, syncing, auth required, failed)
- Red alert badge indicates accounts needing re-authentication
- Click dropdown to see all accounts and their current token validity

## Test plan
- [ ] Verify component renders in header
- [ ] Check that email accounts are fetched and displayed
- [ ] Check that calendar accounts are fetched and displayed
- [ ] Verify status colors match sync state (green=OK, orange=syncing, red=auth required)
- [ ] Test dropdown expand/collapse functionality