### PR TITLE
Refactor todos display to table layout with columns

### DIFF
--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -1329,74 +1329,84 @@ fn todo_list() -> Html {
                 <button type="submit">{"Add"}</button>
             </form>
             <p class="todo-count">{format!("{} todos", sorted_todos.len())}</p>
-            <div class="todo-list">
-                {if sorted_todos.is_empty() {
-                    html! { <p class="empty-state">{"No todos yet! Add one above or approve some decisions."}</p> }
-                } else {
-                    sorted_todos.iter().map(|todo| {
-                        let category = todo.category_id
-                            .and_then(|cat_id| categories_list.iter().find(|c| c.id == cat_id));
-                        let todo_id = todo.id;
-                        let todo_completed = todo.completed;
-                        let toggle = toggle_complete.clone();
-                        let delete = delete_todo.clone();
+            {if sorted_todos.is_empty() {
+                html! { <p class="empty-state">{"No todos yet! Add one above or approve some decisions."}</p> }
+            } else {
+                html! {
+                    <table class="todo-table">
+                        <thead>
+                            <tr>
+                                <th class="col-done">{"Done"}</th>
+                                <th class="col-title">{"Title"}</th>
+                                <th class="col-due">{"Due Date"}</th>
+                                <th class="col-link">{"Link"}</th>
+                                <th class="col-actions">{"Actions"}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {sorted_todos.iter().map(|todo| {
+                                let category = todo.category_id
+                                    .and_then(|cat_id| categories_list.iter().find(|c| c.id == cat_id));
+                                let todo_id = todo.id;
+                                let todo_completed = todo.completed;
+                                let toggle = toggle_complete.clone();
+                                let delete = delete_todo.clone();
 
-                        html! {
-                            <div key={todo.id.to_string()} class={format!("todo-item {}", if todo.completed { "completed" } else { "" })}>
-                                <div class="todo-header">
-                                    <input
-                                        type="checkbox"
-                                        checked={todo.completed}
-                                        onchange={Callback::from(move |_| toggle.emit((todo_id, todo_completed)))}
-                                    />
-                                    <h3 class={if todo.completed { "strikethrough" } else { "" }}>{&todo.title}</h3>
-                                </div>
-                                {if let Some(desc) = &todo.description {
-                                    html! { <p class="description">{desc}</p> }
-                                } else {
-                                    html! {}
-                                }}
-                                {if let Some(due) = &todo.due_date {
-                                    html! {
-                                        <p class="due-date">
-                                            {"Due: "}
-                                            {due.format("%Y-%m-%d %H:%M").to_string()}
-                                        </p>
-                                    }
-                                } else {
-                                    html! {}
-                                }}
-                                {if let Some(link) = &todo.link {
-                                    html! {
-                                        <p class="link">
-                                            <a href={link.clone()} target="_blank">{"View Link"}</a>
-                                        </p>
-                                    }
-                                } else {
-                                    html! {}
-                                }}
-                                <div class="todo-footer">
-                                    {if let Some(cat) = category {
-                                        html! {
-                                            <span class="category-badge" style={format!("background-color: {}", cat.color.as_deref().unwrap_or("#cccccc"))}>
-                                                {&cat.name}
-                                            </span>
-                                        }
-                                    } else {
-                                        html! {}
-                                    }}
-                                    {if todo.decision_id.is_some() {
-                                        html! { <span class="source-badge">{"From Agent"}</span> }
-                                    } else {
-                                        html! {}
-                                    }}
-                                    <button class="delete-btn" onclick={Callback::from(move |_| delete.emit(todo_id))}>{"Delete"}</button>
-                                </div>
-                            </div>
-                        }
-                    }).collect::<Html>()
-                }}
-            </div>
+                                html! {
+                                    <tr key={todo.id.to_string()} class={if todo.completed { "completed" } else { "" }}>
+                                        <td class="col-done">
+                                            <input
+                                                type="checkbox"
+                                                checked={todo.completed}
+                                                onchange={Callback::from(move |_| toggle.emit((todo_id, todo_completed)))}
+                                            />
+                                        </td>
+                                        <td class="col-title">
+                                            <span class={if todo.completed { "strikethrough" } else { "" }}>{&todo.title}</span>
+                                            {if let Some(desc) = &todo.description {
+                                                html! { <span class="todo-description">{" - "}{desc}</span> }
+                                            } else {
+                                                html! {}
+                                            }}
+                                            {if let Some(cat) = category {
+                                                html! {
+                                                    <span class="category-badge" style={format!("background-color: {}", cat.color.as_deref().unwrap_or("#cccccc"))}>
+                                                        {&cat.name}
+                                                    </span>
+                                                }
+                                            } else {
+                                                html! {}
+                                            }}
+                                            {if todo.decision_id.is_some() {
+                                                html! { <span class="source-badge">{"From Agent"}</span> }
+                                            } else {
+                                                html! {}
+                                            }}
+                                        </td>
+                                        <td class="col-due">
+                                            {if let Some(due) = &todo.due_date {
+                                                html! { {due.format("%Y-%m-%d %H:%M").to_string()} }
+                                            } else {
+                                                html! { <span class="empty-cell">{"-"}</span> }
+                                            }}
+                                        </td>
+                                        <td class="col-link">
+                                            {if let Some(link) = &todo.link {
+                                                html! { <a href={link.clone()} target="_blank">{"View"}</a> }
+                                            } else {
+                                                html! { <span class="empty-cell">{"-"}</span> }
+                                            }}
+                                        </td>
+                                        <td class="col-actions">
+                                            <button class="delete-btn" onclick={Callback::from(move |_| delete.emit(todo_id))}>{"Delete"}</button>
+                                        </td>
+                                    </tr>
+                                }
+                            }).collect::<Html>()}
+                        </tbody>
+                    </table>
+                }
+            }}
         </div>
     }
 }

--- a/crates/frontend/styles.css
+++ b/crates/frontend/styles.css
@@ -242,6 +242,110 @@ main {
     margin-bottom: 12px;
 }
 
+/* Todo table styles */
+.todo-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+}
+
+.todo-table thead {
+    background-color: #f9f9f9;
+    border-bottom: 2px solid #ecf0f1;
+}
+
+.todo-table th {
+    padding: 12px 16px;
+    text-align: left;
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.todo-table td {
+    padding: 12px 16px;
+    vertical-align: middle;
+    border-bottom: 1px solid #ecf0f1;
+}
+
+.todo-table tbody tr:hover {
+    background-color: #f9f9f9;
+}
+
+.todo-table tbody tr.completed {
+    opacity: 0.7;
+    background-color: #f5f5f5;
+}
+
+.todo-table .col-done {
+    width: 50px;
+    text-align: center;
+}
+
+.todo-table .col-title {
+    min-width: 200px;
+}
+
+.todo-table .col-due {
+    width: 150px;
+    white-space: nowrap;
+}
+
+.todo-table .col-link {
+    width: 80px;
+    text-align: center;
+}
+
+.todo-table .col-actions {
+    width: 80px;
+    text-align: center;
+}
+
+.todo-table input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+}
+
+.todo-table .strikethrough {
+    text-decoration: line-through;
+    color: #95a5a6;
+}
+
+.todo-table .todo-description {
+    color: #7f8c8d;
+    font-size: 13px;
+}
+
+.todo-table .category-badge {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 12px;
+    color: white;
+    margin-left: 8px;
+}
+
+.todo-table .source-badge {
+    font-size: 10px;
+    padding: 2px 6px;
+    background-color: #3498db;
+    color: white;
+    border-radius: 10px;
+    margin-left: 8px;
+}
+
+.todo-table .empty-cell {
+    color: #bdc3c7;
+}
+
+.todo-table .col-link a {
+    color: #3498db;
+    text-decoration: none;
+}
+
+.todo-table .col-link a:hover {
+    text-decoration: underline;
+}
+
 .todo-item.completed {
     opacity: 0.7;
     border-left-color: #27ae60;


### PR DESCRIPTION
## Summary
- Convert the todos view from card-based layout to a table format
- Add columns for Done (checkbox), Title, Due Date, Link, and Actions
- Consolidate actions to a single delete button column
- Add table-specific CSS styles for proper formatting

## Test plan
- [ ] Build frontend with trunk build
- [ ] Navigate to Todos tab
- [ ] Verify table displays with proper column headers
- [ ] Test checkbox toggling for completion
- [ ] Test delete button functionality
- [ ] Verify links open in new tab when present
- [ ] Check that completed todos are styled with strikethrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)