### PR TITLE
Track per-account sync health with backoff and UI status

### DIFF
--- a/crates/backend/src/db.rs
+++ b/crates/backend/src/db.rs
@@ -1262,13 +1262,17 @@ pub mod google_accounts {
 
         match existing {
             Some(account) => {
-                // Update existing account
+                // Update existing account; a fresh refresh token means any
+                // previous sync failures are stale, so reset health state
                 diesel::update(google_accounts.filter(id.eq(account.id)))
                     .set((
                         name.eq(name_val),
                         refresh_token.eq(refresh_token_val),
                         access_token.eq(access_token_val),
                         token_expires_at.eq(expires_at),
+                        last_sync_error.eq(None::<String>),
+                        last_sync_error_at.eq(None::<DateTime<Utc>>),
+                        consecutive_failures.eq(0),
                         updated_at.eq(Utc::now()),
                     ))
                     .execute(conn)
@@ -1296,5 +1300,50 @@ pub mod google_accounts {
                 Ok(new_account)
             }
         }
+    }
+
+    /// Record a successful poll: clears any error state
+    pub async fn record_sync_success(
+        conn: &mut AsyncPgConnection,
+        account_id: Uuid,
+    ) -> anyhow::Result<()> {
+        use crate::schema::google_accounts::dsl::*;
+
+        diesel::update(google_accounts.filter(id.eq(account_id)))
+            .set((
+                last_synced_at.eq(Utc::now()),
+                last_sync_error.eq(None::<String>),
+                last_sync_error_at.eq(None::<DateTime<Utc>>),
+                consecutive_failures.eq(0),
+                updated_at.eq(Utc::now()),
+            ))
+            .execute(conn)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Record a failed poll: stores the error and bumps the failure counter
+    pub async fn record_sync_failure(
+        conn: &mut AsyncPgConnection,
+        account_id: Uuid,
+        error_message: &str,
+    ) -> anyhow::Result<()> {
+        use crate::schema::google_accounts::dsl::*;
+
+        // Keep stored errors bounded; truncate on a char boundary
+        let truncated: String = error_message.chars().take(500).collect();
+
+        diesel::update(google_accounts.filter(id.eq(account_id)))
+            .set((
+                last_sync_error.eq(truncated),
+                last_sync_error_at.eq(Utc::now()),
+                consecutive_failures.eq(consecutive_failures + 1),
+                updated_at.eq(Utc::now()),
+            ))
+            .execute(conn)
+            .await?;
+
+        Ok(())
     }
 }

--- a/crates/backend/src/pollers/email.rs
+++ b/crates/backend/src/pollers/email.rs
@@ -148,6 +148,17 @@ async fn run_poll_cycle(
             continue;
         }
 
+        // Exponential backoff for accounts that keep failing
+        if let Some(remaining) = backoff_remaining(&account, config.poll_interval) {
+            tracing::debug!(
+                "Skipping {} (backing off after {} failures, {}s remaining)",
+                account.email,
+                account.consecutive_failures,
+                remaining.num_seconds()
+            );
+            continue;
+        }
+
         // Get or create account state
         let state = account_states.entry(account.id).or_default();
 
@@ -163,9 +174,31 @@ async fn run_poll_cycle(
                 }
 
                 rate_limiter.record_poll(&account.email);
+
+                if let Err(e) =
+                    db::google_accounts::record_sync_success(&mut conn, account.id).await
+                {
+                    tracing::warn!("Failed to record sync success for {}: {}", account.email, e);
+                }
             }
             Err(e) => {
-                tracing::error!("Failed to poll {}: {}", account.email, e);
+                tracing::error!("Failed to poll {}: {:#}", account.email, e);
+
+                rate_limiter.record_poll(&account.email);
+
+                if let Err(db_err) = db::google_accounts::record_sync_failure(
+                    &mut conn,
+                    account.id,
+                    &format!("{e:#}"),
+                )
+                .await
+                {
+                    tracing::warn!(
+                        "Failed to record sync failure for {}: {}",
+                        account.email,
+                        db_err
+                    );
+                }
             }
         }
     }
@@ -190,6 +223,28 @@ async fn run_poll_cycle(
     }
 
     Ok(())
+}
+
+/// Maximum backoff between retries of a failing account
+const MAX_BACKOFF: Duration = Duration::from_secs(4 * 60 * 60);
+
+/// If the account has been failing, return how long until the next retry
+/// is allowed. Backoff doubles with each consecutive failure, starting at
+/// the poll interval and capped at [`MAX_BACKOFF`].
+fn backoff_remaining(account: &GoogleAccount, poll_interval: Duration) -> Option<chrono::Duration> {
+    if account.consecutive_failures <= 0 {
+        return None;
+    }
+    let error_at = account.last_sync_error_at?;
+
+    let exponent = (account.consecutive_failures - 1).min(10) as u32;
+    let backoff = poll_interval
+        .saturating_mul(2u32.saturating_pow(exponent))
+        .min(MAX_BACKOFF);
+    let backoff = chrono::Duration::from_std(backoff).ok()?;
+
+    let remaining = error_at + backoff - Utc::now();
+    (remaining > chrono::Duration::zero()).then_some(remaining)
 }
 
 struct PollResult {
@@ -319,4 +374,61 @@ fn parse_from_header(from: &str) -> (String, Option<String>) {
     }
 
     (from.to_string(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn account(failures: i32, error_secs_ago: Option<i64>) -> GoogleAccount {
+        GoogleAccount {
+            id: Uuid::new_v4(),
+            email: "test@example.com".to_string(),
+            name: None,
+            refresh_token: "token".to_string(),
+            access_token: None,
+            token_expires_at: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            last_synced_at: None,
+            last_sync_error: failures.gt(&0).then(|| "boom".to_string()),
+            last_sync_error_at: error_secs_ago.map(|s| Utc::now() - chrono::Duration::seconds(s)),
+            consecutive_failures: failures,
+        }
+    }
+
+    const INTERVAL: Duration = Duration::from_secs(300);
+
+    #[test]
+    fn healthy_account_has_no_backoff() {
+        assert!(backoff_remaining(&account(0, None), INTERVAL).is_none());
+    }
+
+    #[test]
+    fn recent_failure_backs_off() {
+        let remaining = backoff_remaining(&account(1, Some(10)), INTERVAL).unwrap();
+        assert!(remaining.num_seconds() <= 290);
+        assert!(remaining.num_seconds() > 200);
+    }
+
+    #[test]
+    fn backoff_expires_after_interval() {
+        assert!(backoff_remaining(&account(1, Some(301)), INTERVAL).is_none());
+    }
+
+    #[test]
+    fn backoff_doubles_with_failures() {
+        // 3 failures -> 4x poll interval = 1200s
+        let remaining = backoff_remaining(&account(3, Some(10)), INTERVAL).unwrap();
+        assert!(remaining.num_seconds() > 1100);
+        assert!(remaining.num_seconds() <= 1190);
+    }
+
+    #[test]
+    fn backoff_is_capped() {
+        // 20 failures would be ~4 years uncapped; must be <= 4h
+        let remaining = backoff_remaining(&account(20, Some(0)), INTERVAL).unwrap();
+        assert!(remaining.num_seconds() <= 4 * 60 * 60);
+        assert!(remaining.num_seconds() > 4 * 60 * 60 - 60);
+    }
 }

--- a/crates/backend/src/schema.rs
+++ b/crates/backend/src/schema.rs
@@ -138,6 +138,10 @@ diesel::table! {
         token_expires_at -> Nullable<Timestamptz>,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        last_synced_at -> Nullable<Timestamptz>,
+        last_sync_error -> Nullable<Text>,
+        last_sync_error_at -> Nullable<Timestamptz>,
+        consecutive_failures -> Int4,
     }
 }
 

--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -156,6 +156,20 @@ pub fn app_context_provider(props: &AppContextProviderProps) -> Html {
 // ============================================================================
 
 /// AccountStatus shows connected Google accounts in the header
+/// Format a past timestamp as a short relative time like "3m ago"
+fn format_relative_time(time: &chrono::DateTime<chrono::Utc>) -> String {
+    let elapsed = chrono::Utc::now() - *time;
+    if elapsed.num_seconds() < 60 {
+        "just now".to_string()
+    } else if elapsed.num_minutes() < 60 {
+        format!("{}m ago", elapsed.num_minutes())
+    } else if elapsed.num_hours() < 24 {
+        format!("{}h ago", elapsed.num_hours())
+    } else {
+        format!("{}d ago", elapsed.num_days())
+    }
+}
+
 #[function_component(AccountStatus)]
 fn account_status() -> Html {
     let accounts = use_state(Vec::<GoogleAccountResponse>::new);
@@ -185,12 +199,21 @@ fn account_status() -> Html {
     };
 
     let total_accounts = accounts.len();
+    let error_count = accounts
+        .iter()
+        .filter(|a| a.last_sync_error.is_some())
+        .count();
 
     html! {
         <div class="account-status-container">
             <button class="account-status-btn" onclick={toggle_expanded.clone()}>
                 <span class="account-status-icon">{"@"}</span>
                 <span class="account-status-count">{total_accounts}</span>
+                {if error_count > 0 {
+                    html! { <span class="account-status-alert">{error_count}</span> }
+                } else {
+                    html! {}
+                }}
             </button>
 
             {if *expanded {
@@ -206,8 +229,31 @@ fn account_status() -> Html {
                                 html! { <div class="account-empty">{"No accounts connected"}</div> }
                             } else {
                                 account_list.iter().map(|account| {
+                                    let (item_class, dot_class, status_text, status_title) =
+                                        if let Some(error) = &account.last_sync_error {
+                                            (
+                                                "account-item status-error",
+                                                "status-dot status-error",
+                                                format!("Sync failing ({}x)", account.consecutive_failures),
+                                                error.clone(),
+                                            )
+                                        } else if let Some(synced) = &account.last_synced_at {
+                                            (
+                                                "account-item status-ok",
+                                                "status-dot status-ok",
+                                                format!("Synced {}", format_relative_time(synced)),
+                                                String::new(),
+                                            )
+                                        } else {
+                                            (
+                                                "account-item status-ok",
+                                                "status-dot status-syncing",
+                                                "Waiting for first sync".to_string(),
+                                                String::new(),
+                                            )
+                                        };
                                     html! {
-                                        <div key={account.id.to_string()} class="account-item status-ok">
+                                        <div key={account.id.to_string()} class={item_class}>
                                             <div class="account-info">
                                                 <span class="account-email">{&account.email}</span>
                                                 {if let Some(name) = &account.name {
@@ -216,9 +262,9 @@ fn account_status() -> Html {
                                                     html! {}
                                                 }}
                                             </div>
-                                            <div class="account-status-indicator">
-                                                <span class="status-dot status-ok"></span>
-                                                <span class="status-text">{"Connected"}</span>
+                                            <div class="account-status-indicator" title={status_title}>
+                                                <span class={dot_class}></span>
+                                                <span class="status-text">{status_text}</span>
                                             </div>
                                         </div>
                                     }

--- a/crates/shared-types/src/lib.rs
+++ b/crates/shared-types/src/lib.rs
@@ -125,15 +125,23 @@ pub struct GoogleAccount {
     pub token_expires_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub last_synced_at: Option<DateTime<Utc>>,
+    pub last_sync_error: Option<String>,
+    pub last_sync_error_at: Option<DateTime<Utc>>,
+    pub consecutive_failures: i32,
 }
 
 /// API response for Google account (excludes sensitive tokens)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GoogleAccountResponse {
     pub id: Uuid,
     pub email: String,
     pub name: Option<String>,
     pub created_at: DateTime<Utc>,
+    pub last_synced_at: Option<DateTime<Utc>>,
+    pub last_sync_error: Option<String>,
+    pub last_sync_error_at: Option<DateTime<Utc>>,
+    pub consecutive_failures: i32,
 }
 
 impl From<GoogleAccount> for GoogleAccountResponse {
@@ -143,6 +151,10 @@ impl From<GoogleAccount> for GoogleAccountResponse {
             email: account.email,
             name: account.name,
             created_at: account.created_at,
+            last_synced_at: account.last_synced_at,
+            last_sync_error: account.last_sync_error,
+            last_sync_error_at: account.last_sync_error_at,
+            consecutive_failures: account.consecutive_failures,
         }
     }
 }

--- a/migrations/2026-08-01-000001_add_sync_health_to_google_accounts/down.sql
+++ b/migrations/2026-08-01-000001_add_sync_health_to_google_accounts/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE google_accounts
+    DROP COLUMN last_synced_at,
+    DROP COLUMN last_sync_error,
+    DROP COLUMN last_sync_error_at,
+    DROP COLUMN consecutive_failures;

--- a/migrations/2026-08-01-000001_add_sync_health_to_google_accounts/up.sql
+++ b/migrations/2026-08-01-000001_add_sync_health_to_google_accounts/up.sql
@@ -1,0 +1,6 @@
+-- Track per-account sync health so failing accounts are visible and can back off
+ALTER TABLE google_accounts
+    ADD COLUMN last_synced_at TIMESTAMPTZ,
+    ADD COLUMN last_sync_error TEXT,
+    ADD COLUMN last_sync_error_at TIMESTAMPTZ,
+    ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary

Makes email-account failures visible and self-limiting. Previously a dead refresh token was retried at full speed forever and surfaced only as a repeating log line — nothing in the API or UI showed an inbox had gone dark.

- **Migration**: adds `last_synced_at`, `last_sync_error`, `last_sync_error_at`, `consecutive_failures` to `google_accounts`.
- **Poller**: records success (clears error state) and failure (stores error, bumps counter) per account. Failing accounts back off exponentially — poll interval doubling per consecutive failure, capped at 4 hours. Re-login resets health state since a fresh refresh token invalidates prior failures.
- **API**: `GET /api/google-accounts` now includes the health fields (tokens still stripped).
- **UI**: the account dropdown shows per-account status — "Synced 3m ago", "Waiting for first sync", or "Sync failing (Nx)" with the error in a tooltip — plus an alert badge on the header button when any account is failing.

## Testing

- 5 new unit tests covering the backoff schedule (none / active / expired / doubling / cap)
- `cargo test --workspace`, `cargo clippy --workspace --all-features`, `cargo fmt` — all clean