### PR TITLE
Fix email insert ON CONFLICT target — emails never persisted

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -70,6 +70,7 @@ This is a Rust workspace with 3 crates:
 - Container build/push: `.github/workflows/container.yml` (pushes `ghcr.io/meawoppl/agentive-inversion:main`)
 - Deployment is automatic: watchtower on the production host polls the `:main` tag and redeploys within ~5 minutes of a merge. There is no deploy workflow; do not retag the image without coordinating with infrastructure.
 - The container entrypoint runs migrations before starting the server; migrations must be idempotent (use `IF NOT EXISTS` / `IF EXISTS`)
+- Upsert conflict targets must match an actual unique constraint on the table (e.g. emails is UNIQUE(account_id, gmail_id), not gmail_id alone) — Postgres rejects the INSERT at runtime otherwise, and Diesel won't catch it at compile time
 
 ## Common Commands
 

--- a/crates/backend/src/db.rs
+++ b/crates/backend/src/db.rs
@@ -306,7 +306,9 @@ pub mod emails {
         Ok(count)
     }
 
-    /// Insert a new email, returning None if it already exists (by gmail_id)
+    /// Insert a new email, returning None if this account already has it.
+    /// Gmail ids are only unique per mailbox, so the conflict target must be
+    /// (account_id, gmail_id) — matching the table's unique constraint.
     pub async fn insert(
         conn: &mut AsyncPgConnection,
         new_email: NewEmail,
@@ -315,7 +317,7 @@ pub mod emails {
 
         let result = diesel::insert_into(emails)
             .values(&new_email)
-            .on_conflict(gmail_id)
+            .on_conflict((account_id, gmail_id))
             .do_nothing()
             .get_result::<Email>(conn)
             .await

--- a/crates/backend/src/pollers/email.rs
+++ b/crates/backend/src/pollers/email.rs
@@ -288,6 +288,8 @@ async fn save_emails_to_db(
 ) -> Result<usize> {
     let mut conn = pool.get().await.context("Failed to get DB connection")?;
     let mut count = 0;
+    let mut failed = 0;
+    let mut last_error = None;
 
     for email in emails {
         // Parse "From" header into address and name
@@ -348,8 +350,19 @@ async fn save_emails_to_db(
             }
             Err(e) => {
                 tracing::warn!("  Failed to store {}: {}", email.id, e);
+                failed += 1;
+                last_error = Some(e);
             }
         }
+    }
+
+    // A fully-failed batch means something systemic (schema mismatch, dead
+    // connection) — surface it as a poll failure so account health shows it,
+    // rather than logging per-message warnings and reporting success
+    if failed > 0 && failed == emails.len() {
+        return Err(last_error
+            .unwrap_or_else(|| anyhow::anyhow!("unknown insert error"))
+            .context(format!("all {failed} email inserts failed")));
     }
 
     Ok(count)


### PR DESCRIPTION
## Summary

Email storage has never worked: `db::emails::insert` used `ON CONFLICT (gmail_id)`, but the table's unique constraint is `UNIQUE (account_id, gmail_id)`. Postgres rejects the INSERT at runtime (`no unique or exclusion constraint matching the ON CONFLICT specification`), so every fetched email failed to persist — logged as a per-message WARN while the poll cycle reported success. Production logs show 100/100 inserts failing per cycle and `count(*) = 0` in `emails`, ever.

- Conflict target changed to `(account_id, gmail_id)`, matching the constraint. Deliberately **not** adding a global unique on `gmail_id`: Gmail ids are only unique per mailbox, and a global constraint would make colliding ids across the two connected accounts silently swallow mail via `DO NOTHING`.
- `save_emails_to_db` now returns an error when an entire non-empty batch fails to insert, so a systemic storage failure trips the account-health failure path (visible in the UI, backs off) instead of hiding behind per-message warnings and a "successful" poll.
- CLAUDE.md: added the rule that upsert conflict targets must match an actual unique constraint (Diesel can't catch this at compile time).

Checked the rest of the codebase: this was the only `on_conflict` call; the calendar_events upsert is a select-then-update keyed on `(account_id, google_event_id)` and is unaffected.

## Testing

- `cargo test --workspace`, `cargo clippy --workspace --all-features`, `cargo fmt` — clean
- Real verification is production: after deploy, `emails` should start filling within one poll cycle (~5 min); infrastructure is watching row counts server-side