### PR TITLE
Triage pipeline foundations: about-me doc, Gmail labels, calendar writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "diesel-async",
  "dotenvy",
  "futures",
+ "google-calendar3",
  "google-gmail1",
  "hyper",
  "hyper-util",
@@ -1251,6 +1252,26 @@ dependencies = [
  "itertools",
  "mime",
  "percent-encoding",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tokio",
+ "url",
+ "yup-oauth2 11.0.0",
+]
+
+[[package]]
+name = "google-calendar3"
+version = "6.0.0+20240523"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eecfc108ae1dc04a710b8db3a79e15ab3e87bda7735e0f84df9bf4d4e1496cf6"
+dependencies = [
+ "chrono",
+ "google-apis-common",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "mime",
  "serde",
  "serde_json",
  "serde_with",

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -44,6 +44,7 @@ hyper-util = { version = "0.1.18", features = ["client-legacy"] }
 async-trait = "0.1.89"
 jsonwebtoken = "9"
 cookie = "0.18"
+google-calendar3 = "6.0.0"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/backend/src/calendar_writer.rs
+++ b/crates/backend/src/calendar_writer.rs
@@ -1,0 +1,159 @@
+//! Google Calendar event creation using stored OAuth tokens.
+//!
+//! Agent-created events land on a dedicated calendar (default "Agent") so
+//! they never pollute the primary calendar and can be toggled or audited
+//! as a group. Events link back to their source email.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use google_calendar3::api::{Calendar, Event, EventDateTime, EventSource};
+use google_calendar3::hyper_rustls::HttpsConnector;
+use google_calendar3::CalendarHub;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioExecutor;
+use shared_types::GoogleAccount;
+
+pub struct CalendarWriter {
+    hub: CalendarHub<HttpsConnector<HttpConnector>>,
+}
+
+/// Event to create on the agent calendar
+#[derive(Debug, Clone)]
+pub struct NewCalendarEvent {
+    pub summary: String,
+    pub description: Option<String>,
+    pub location: Option<String>,
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    /// Link back to the source email (Gmail URL)
+    pub email_link: Option<String>,
+}
+
+/// Result of a successful event creation
+#[derive(Debug, Clone)]
+pub struct CreatedEvent {
+    pub google_event_id: String,
+    pub html_link: Option<String>,
+    pub calendar_id: String,
+}
+
+impl CalendarWriter {
+    /// Build a client from a GoogleAccount's stored refresh token
+    pub async fn from_account(account: &GoogleAccount) -> Result<Self> {
+        let client_id = std::env::var("GOOGLE_CLIENT_ID")
+            .context("GOOGLE_CLIENT_ID environment variable must be set")?;
+        let client_secret = std::env::var("GOOGLE_CLIENT_SECRET")
+            .context("GOOGLE_CLIENT_SECRET environment variable must be set")?;
+
+        let secret = google_calendar3::yup_oauth2::authorized_user::AuthorizedUserSecret {
+            client_id,
+            client_secret,
+            refresh_token: account.refresh_token.clone(),
+            key_type: "authorized_user".to_string(),
+        };
+
+        let auth = google_calendar3::yup_oauth2::AuthorizedUserAuthenticator::builder(secret)
+            .build()
+            .await
+            .context("Failed to build authenticator from refresh token")?;
+
+        let connector = google_calendar3::hyper_rustls::HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .context("Failed to load native TLS roots")?
+            .https_or_http()
+            .enable_http1()
+            .build();
+
+        let client = Client::builder(TokioExecutor::new()).build(connector);
+        let hub = CalendarHub::new(client, auth);
+
+        Ok(Self { hub })
+    }
+
+    /// Find a calendar by summary, creating it if missing. Returns its ID.
+    pub async fn ensure_calendar(&self, name: &str) -> Result<String> {
+        let (_, list) = self
+            .hub
+            .calendar_list()
+            .list()
+            .doit()
+            .await
+            .context("Failed to list calendars")?;
+
+        if let Some(items) = list.items {
+            for cal in items {
+                if cal.summary.as_deref() == Some(name) {
+                    return cal.id.context("Calendar has no ID");
+                }
+            }
+        }
+
+        let new_calendar = Calendar {
+            summary: Some(name.to_string()),
+            description: Some("Events created by the agentive-inversion triage agent".to_string()),
+            ..Default::default()
+        };
+
+        let (_, created) = self
+            .hub
+            .calendars()
+            .insert(new_calendar)
+            .doit()
+            .await
+            .context("Failed to create calendar")?;
+
+        tracing::info!("Created calendar '{}'", name);
+        created.id.context("Created calendar has no ID")
+    }
+
+    /// Create an event, linking back to the source email in both the
+    /// description and the event source field
+    pub async fn create_event(
+        &self,
+        calendar_id: &str,
+        event: NewCalendarEvent,
+    ) -> Result<CreatedEvent> {
+        let description = match (&event.description, &event.email_link) {
+            (Some(d), Some(link)) => Some(format!("{d}\n\nSource email: {link}")),
+            (None, Some(link)) => Some(format!("Source email: {link}")),
+            (Some(d), None) => Some(d.clone()),
+            (None, None) => None,
+        };
+
+        let source = event.email_link.as_ref().map(|link| EventSource {
+            title: Some("Source email".to_string()),
+            url: Some(link.clone()),
+        });
+
+        let api_event = Event {
+            summary: Some(event.summary),
+            description,
+            location: event.location,
+            start: Some(EventDateTime {
+                date_time: Some(event.start),
+                ..Default::default()
+            }),
+            end: Some(EventDateTime {
+                date_time: Some(event.end),
+                ..Default::default()
+            }),
+            source,
+            ..Default::default()
+        };
+
+        let (_, created) = self
+            .hub
+            .events()
+            .insert(api_event, calendar_id)
+            .doit()
+            .await
+            .context("Failed to create event")?;
+
+        Ok(CreatedEvent {
+            google_event_id: created.id.context("Created event has no ID")?,
+            html_link: created.html_link,
+            calendar_id: calendar_id.to_string(),
+        })
+    }
+}

--- a/crates/backend/src/db.rs
+++ b/crates/backend/src/db.rs
@@ -223,6 +223,8 @@ pub mod emails {
         pub processed: bool,
         pub processed_at: Option<DateTime<Utc>>,
         pub archived_in_gmail: bool,
+        pub triage_status: String,
+        pub triaged_at: Option<DateTime<Utc>>,
     }
 
     pub async fn list_all(
@@ -339,6 +341,104 @@ pub mod emails {
             .await?;
 
         Ok(())
+    }
+
+    /// List emails awaiting triage by the agent pipeline, oldest first
+    pub async fn list_pending_triage(
+        conn: &mut AsyncPgConnection,
+        limit: i64,
+    ) -> anyhow::Result<Vec<Email>> {
+        use crate::schema::emails::dsl::*;
+
+        let items = emails
+            .filter(triage_status.eq("pending"))
+            .order_by(fetched_at.asc())
+            .limit(limit)
+            .load::<Email>(conn)
+            .await?;
+
+        Ok(items)
+    }
+
+    /// Record the triage pipeline's disposition for an email
+    pub async fn set_triage_status(
+        conn: &mut AsyncPgConnection,
+        email_id: Uuid,
+        status: &str,
+    ) -> anyhow::Result<()> {
+        use crate::schema::emails::dsl::*;
+
+        diesel::update(emails.filter(id.eq(email_id)))
+            .set((triage_status.eq(status), triaged_at.eq(Some(Utc::now()))))
+            .execute(conn)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Record that the email was archived in Gmail by the agent
+    pub async fn mark_archived_in_gmail(
+        conn: &mut AsyncPgConnection,
+        email_id: Uuid,
+    ) -> anyhow::Result<()> {
+        use crate::schema::emails::dsl::*;
+
+        diesel::update(emails.filter(id.eq(email_id)))
+            .set(archived_in_gmail.eq(true))
+            .execute(conn)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Counts by triage status for the pipeline display
+    pub async fn triage_status_counts(
+        conn: &mut AsyncPgConnection,
+    ) -> anyhow::Result<Vec<(String, i64)>> {
+        use crate::schema::emails::dsl::*;
+        use diesel::dsl::count_star;
+
+        let counts = emails
+            .group_by(triage_status)
+            .select((triage_status, count_star()))
+            .load::<(String, i64)>(conn)
+            .await?;
+
+        Ok(counts)
+    }
+}
+
+// Personal-context document read by the triage agent (single-row table)
+pub mod about_me {
+    use super::*;
+
+    #[derive(Debug, Clone, Queryable)]
+    pub struct AboutMe {
+        #[allow(dead_code)] // required for positional Queryable mapping
+        pub id: i32,
+        pub content: String,
+        pub updated_at: DateTime<Utc>,
+    }
+
+    pub async fn get(conn: &mut AsyncPgConnection) -> anyhow::Result<AboutMe> {
+        use crate::schema::about_me::dsl::*;
+
+        let doc = about_me.filter(id.eq(1)).first::<AboutMe>(conn).await?;
+        Ok(doc)
+    }
+
+    pub async fn update(
+        conn: &mut AsyncPgConnection,
+        new_content: &str,
+    ) -> anyhow::Result<AboutMe> {
+        use crate::schema::about_me::dsl::*;
+
+        let doc = diesel::update(about_me.filter(id.eq(1)))
+            .set((content.eq(new_content), updated_at.eq(Utc::now())))
+            .get_result::<AboutMe>(conn)
+            .await?;
+
+        Ok(doc)
     }
 }
 
@@ -1250,6 +1350,22 @@ pub mod google_accounts {
             .await?;
 
         Ok(accounts)
+    }
+
+    /// Look up an account by email address
+    pub async fn get_by_email(
+        conn: &mut AsyncPgConnection,
+        email_addr: &str,
+    ) -> anyhow::Result<Option<GoogleAccount>> {
+        use crate::schema::google_accounts::dsl::*;
+
+        let account = google_accounts
+            .filter(email.eq(email_addr))
+            .first::<GoogleAccount>(conn)
+            .await
+            .optional()?;
+
+        Ok(account)
     }
 
     pub async fn upsert(

--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -4,19 +4,21 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use shared_types::{
-    AgentDecisionResponse, AgentRuleResponse, ApproveDecisionRequest, BatchApproveDecisionsRequest,
-    BatchOperationFailure, BatchOperationResponse, BatchRejectDecisionsRequest, CalendarEventQuery,
-    CalendarEventResponse, Category, ChatHistoryQuery, ChatIntent, ChatMessageResponse,
-    ChatResponse, CreateAgentDecisionRequest, CreateAgentRuleRequest, CreateCategoryRequest,
-    CreateTodoRequest, DecisionStats, EmailListQuery, EmailResponse, GoogleAccountResponse,
-    RejectDecisionRequest, RuleListQuery, SendChatMessageRequest, SuggestedAction, Todo,
-    UpdateAgentRuleRequest, UpdateCategoryRequest, UpdateTodoRequest,
+    AboutMeResponse, AgentDecisionResponse, AgentRuleResponse, ApproveDecisionRequest,
+    BatchApproveDecisionsRequest, BatchOperationFailure, BatchOperationResponse,
+    BatchRejectDecisionsRequest, CalendarEventQuery, CalendarEventResponse, Category,
+    ChatHistoryQuery, ChatIntent, ChatMessageResponse, ChatResponse, CreateAgentDecisionRequest,
+    CreateAgentRuleRequest, CreateCalendarEventRequest, CreateCalendarEventResponse,
+    CreateCategoryRequest, CreateTodoRequest, DecisionStats, EmailListQuery, EmailResponse,
+    GoogleAccountResponse, RejectDecisionRequest, RuleListQuery, SendChatMessageRequest,
+    SuggestedAction, Todo, UpdateAboutMeRequest, UpdateAgentRuleRequest, UpdateCategoryRequest,
+    UpdateTodoRequest,
 };
 use uuid::Uuid;
 
 // Authentication is handled by middleware layer in main.rs
 use crate::db::{
-    agent_rules, calendar_events, categories, chat_messages, decisions, emails, get_conn,
+    about_me, agent_rules, calendar_events, categories, chat_messages, decisions, emails, get_conn,
     google_accounts, todos,
 };
 use crate::error::{ApiError, ApiResult};
@@ -158,6 +160,7 @@ pub async fn list_emails(
             received_at: e.received_at,
             processed: e.processed,
             archived_in_gmail: e.archived_in_gmail,
+            triage_status: e.triage_status,
         })
         .collect();
 
@@ -185,6 +188,7 @@ pub async fn get_email(
         received_at: email.received_at,
         processed: email.processed,
         archived_in_gmail: email.archived_in_gmail,
+        triage_status: email.triage_status,
     }))
 }
 
@@ -199,6 +203,75 @@ pub async fn get_email_stats(State(state): State<AppState>) -> ApiResult<Json<Em
     let total = emails::count_all(&mut conn).await?;
     let unprocessed = emails::count_unprocessed(&mut conn).await?;
     Ok(Json(EmailStatsResponse { total, unprocessed }))
+}
+
+// About-me document handlers
+pub async fn get_about_me(State(state): State<AppState>) -> ApiResult<Json<AboutMeResponse>> {
+    let mut conn = get_conn(&state.pool).await?;
+    let doc = about_me::get(&mut conn).await?;
+    Ok(Json(AboutMeResponse {
+        content: doc.content,
+        updated_at: doc.updated_at,
+    }))
+}
+
+pub async fn update_about_me(
+    State(state): State<AppState>,
+    Json(req): Json<UpdateAboutMeRequest>,
+) -> ApiResult<Json<AboutMeResponse>> {
+    let mut conn = get_conn(&state.pool).await?;
+    let doc = about_me::update(&mut conn, &req.content).await?;
+    Ok(Json(AboutMeResponse {
+        content: doc.content,
+        updated_at: doc.updated_at,
+    }))
+}
+
+// Calendar event creation (executes a write to the agent calendar)
+pub async fn create_calendar_event(
+    State(state): State<AppState>,
+    Json(req): Json<CreateCalendarEventRequest>,
+) -> ApiResult<Json<CreateCalendarEventResponse>> {
+    use crate::calendar_writer::{CalendarWriter, NewCalendarEvent};
+
+    let mut conn = get_conn(&state.pool).await?;
+    let account = google_accounts::get_by_email(&mut conn, &req.account_email)
+        .await?
+        .ok_or_else(|| {
+            ApiError::NotFound(format!("No connected account: {}", req.account_email))
+        })?;
+    drop(conn);
+
+    let writer = CalendarWriter::from_account(&account)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let calendar_name = req.calendar_name.as_deref().unwrap_or("Agent");
+    let calendar_id = writer
+        .ensure_calendar(calendar_name)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let created = writer
+        .create_event(
+            &calendar_id,
+            NewCalendarEvent {
+                summary: req.summary,
+                description: req.description,
+                location: req.location,
+                start: req.start,
+                end: req.end,
+                email_link: req.email_link,
+            },
+        )
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok(Json(CreateCalendarEventResponse {
+        google_event_id: created.google_event_id,
+        html_link: created.html_link,
+        calendar_id: created.calendar_id,
+    }))
 }
 
 // ============================================================================

--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -11,6 +11,7 @@ use tower_http::{
 };
 
 mod auth;
+mod calendar_writer;
 mod db;
 pub mod error;
 mod handlers;
@@ -77,6 +78,9 @@ async fn main() -> anyhow::Result<()> {
         .route("/todos/:id", delete(handlers::delete_todo))
         // Google account routes (for viewing connected accounts)
         .route("/google-accounts", get(handlers::list_google_accounts))
+        // About-me document (personal context for the triage agent)
+        .route("/about-me", get(handlers::get_about_me))
+        .route("/about-me", put(handlers::update_about_me))
         // Category routes
         .route("/categories", get(handlers::list_categories))
         .route("/categories", post(handlers::create_category))
@@ -117,6 +121,10 @@ async fn main() -> anyhow::Result<()> {
         .route("/chat/history", get(handlers::get_chat_history))
         .route("/chat/history", delete(handlers::clear_chat_history))
         // Calendar event routes
+        .route(
+            "/calendar-events/create",
+            post(handlers::create_calendar_event),
+        )
         .route("/calendar-events", get(handlers::list_calendar_events))
         .route("/calendar-events/today", get(handlers::get_todays_events))
         .route(

--- a/crates/backend/src/pollers/gmail_client.rs
+++ b/crates/backend/src/pollers/gmail_client.rs
@@ -196,6 +196,65 @@ impl GmailClient {
         Ok(())
     }
 
+    /// Find a user label by name, creating it if it doesn't exist yet.
+    /// Returns the label ID (Gmail label IDs differ from display names).
+    #[allow(dead_code)] // invoked by the triage orchestrator
+    pub async fn ensure_label(&self, label_name: &str) -> Result<String> {
+        let (_, label_list) = self
+            .hub
+            .users()
+            .labels_list("me")
+            .doit()
+            .await
+            .context("Failed to list labels")?;
+
+        if let Some(labels) = label_list.labels {
+            for label in labels {
+                if label.name.as_deref() == Some(label_name) {
+                    return label.id.context("Label has no ID");
+                }
+            }
+        }
+
+        let new_label = google_gmail1::api::Label {
+            name: Some(label_name.to_string()),
+            label_list_visibility: Some("labelShow".to_string()),
+            message_list_visibility: Some("show".to_string()),
+            ..Default::default()
+        };
+
+        let (_, created) = self
+            .hub
+            .users()
+            .labels_create(new_label, "me")
+            .doit()
+            .await
+            .context("Failed to create label")?;
+
+        tracing::info!("Created Gmail label '{}'", label_name);
+        created.id.context("Created label has no ID")
+    }
+
+    /// Archive a message and tag it with the given label so agent actions
+    /// stay identifiable and recoverable in Gmail
+    #[allow(dead_code)] // invoked by the triage orchestrator
+    pub async fn archive_with_label(&self, message_id: &str, label_id: &str) -> Result<()> {
+        let modify_request = google_gmail1::api::ModifyMessageRequest {
+            remove_label_ids: Some(vec!["INBOX".to_string()]),
+            add_label_ids: Some(vec![label_id.to_string()]),
+        };
+
+        self.hub
+            .users()
+            .messages_modify(modify_request, "me", message_id)
+            .doit()
+            .await
+            .context("Failed to archive message with label")?;
+
+        tracing::info!("Archived message {} with agent label", message_id);
+        Ok(())
+    }
+
     fn parse_message(message: Message) -> EmailMessage {
         let id = message.id.clone().unwrap_or_default();
         let thread_id = message.thread_id.clone().unwrap_or_default();

--- a/crates/backend/src/schema.rs
+++ b/crates/backend/src/schema.rs
@@ -125,6 +125,16 @@ diesel::table! {
         processed -> Bool,
         processed_at -> Nullable<Timestamptz>,
         archived_in_gmail -> Bool,
+        triage_status -> Varchar,
+        triaged_at -> Nullable<Timestamptz>,
+    }
+}
+
+diesel::table! {
+    about_me (id) {
+        id -> Int4,
+        content -> Text,
+        updated_at -> Timestamptz,
     }
 }
 

--- a/crates/shared-types/src/lib.rs
+++ b/crates/shared-types/src/lib.rs
@@ -290,6 +290,44 @@ pub struct EmailResponse {
     pub received_at: DateTime<Utc>,
     pub processed: bool,
     pub archived_in_gmail: bool,
+    pub triage_status: String,
+}
+
+/// Personal-context document the triage agent reads before proposing actions
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AboutMeResponse {
+    pub content: String,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Request to replace the about-me document
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateAboutMeRequest {
+    pub content: String,
+}
+
+/// Request to create an event on the agent calendar (executed by the backend
+/// with the account's stored OAuth tokens)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateCalendarEventRequest {
+    pub account_email: String,
+    pub summary: String,
+    pub description: Option<String>,
+    pub location: Option<String>,
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    /// Link back to the source email (Gmail URL)
+    pub email_link: Option<String>,
+    /// Target calendar name; defaults to "Agent"
+    pub calendar_name: Option<String>,
+}
+
+/// Result of creating an event on the agent calendar
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateCalendarEventResponse {
+    pub google_event_id: String,
+    pub html_link: Option<String>,
+    pub calendar_id: String,
 }
 
 /// Query parameters for listing emails

--- a/migrations/2026-08-02-000001_add_about_me_and_email_triage/down.sql
+++ b/migrations/2026-08-02-000001_add_about_me_and_email_triage/down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_emails_triage_pending;
+ALTER TABLE emails
+    DROP COLUMN IF EXISTS triage_status,
+    DROP COLUMN IF EXISTS triaged_at;
+DROP TABLE IF EXISTS about_me;

--- a/migrations/2026-08-02-000001_add_about_me_and_email_triage/up.sql
+++ b/migrations/2026-08-02-000001_add_about_me_and_email_triage/up.sql
@@ -1,0 +1,18 @@
+-- Personal context document the triage agent reads before proposing todos.
+-- Stored in the database because the repo is public; single-row table.
+CREATE TABLE IF NOT EXISTS about_me (
+    id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    content TEXT NOT NULL DEFAULT '',
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO about_me (id, content) VALUES (1, '') ON CONFLICT (id) DO NOTHING;
+
+-- Pipeline state for the multi-model triage flow. Emails stay 'pending' until
+-- the screening pass runs; terminal states record what the pipeline did.
+ALTER TABLE emails
+    ADD COLUMN IF NOT EXISTS triage_status VARCHAR NOT NULL DEFAULT 'pending',
+    ADD COLUMN IF NOT EXISTS triaged_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_emails_triage_pending
+    ON emails (fetched_at) WHERE triage_status = 'pending';


### PR DESCRIPTION
## Summary

First of three PRs replacing the keyword classifier with a multi-model agentic triage pipeline (Haiku screening → Sonnet 4.5 archive determinations → Opus 4.8 todo decisions, driven through the claude-codes crate). This PR is the write-capable plumbing; no pipeline behavior changes yet.

- **`about_me` table + `GET/PUT /api/about-me`** — single-row personal-context document the Opus tier reads before proposing todos. DB-stored because the repo is public; editable via API (UI editor comes in PR C).
- **`emails.triage_status` / `triaged_at`** — pipeline state per email (`pending` until screened; partial index on pending). Exposed in `EmailResponse` for the upcoming pipeline screen. Migration is idempotent per the new house rule.
- **Gmail label support** — `ensure_label()` (find-or-create, returns label ID) and `archive_with_label()` (remove INBOX + tag `agent-archived`) so every agent archive stays identifiable and recoverable. Scopes already granted (`gmail.modify` since #80).
- **Calendar writer + `POST /api/calendar-events/create`** — creates events via stored OAuth tokens on a dedicated **"Agent" calendar** (find-or-create by name), never the primary calendar. Events carry a link back to the source email in both description and the event `source` field. This is the execution half of the gated calendar flow: PR B has agents *propose* events as decisions; approval calls this.
- New db helpers: `google_accounts::get_by_email`, `emails::{list_pending_triage, set_triage_status, mark_archived_in_gmail, triage_status_counts}`.

## Testing

- `cargo test --workspace`, `cargo clippy --workspace --all-features` (zero warnings), `cargo fmt` — clean
- Google-API paths (label create, calendar create/insert) are exercised in production once PR B wires them into the pipeline; endpoints are auth-protected and callable for manual verification