### PR TITLE
Multi-model agentic triage pipeline (Haiku/Sonnet/Opus via claude-codes)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,15 @@ RUST_LOG=info
 # Only needed if frontend is served from a different origin
 # For single-container deployment, CORS is typically not needed
 # CORS_ALLOWED_ORIGINS=https://your-frontend.com
+
+# ============================================================================
+# Agentic Triage Pipeline (optional - falls back to keyword heuristic if unset)
+# ============================================================================
+# Anthropic API key for the claude CLI driven triage sessions
+# ANTHROPIC_API_KEY=sk-ant-...
+# TRIAGE_POLL_INTERVAL_SECS=300
+# TRIAGE_BATCH_SIZE=20
+# TRIAGE_SCREEN_MODEL=claude-haiku-4-5
+# TRIAGE_ARCHIVE_MODEL=claude-sonnet-4-5
+# TRIAGE_ACTION_MODEL=claude-opus-4-8
+# TRIAGE_SESSION_TIMEOUT_SECS=600

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "claude-codes",
  "cookie",
  "diesel",
  "diesel-async",
@@ -208,6 +209,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shared-types",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-postgres",
@@ -352,6 +354,23 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "claude-codes"
+version = "2.1.220"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1e407233d670143da2462d1a7ba7fdeea0164e38aef317362611e9f1a8f78f"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "uuid",
+ "which",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1748,9 +1767,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
@@ -1764,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1785,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matchers"
@@ -2406,9 +2425,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -2902,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
@@ -3043,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -3590,6 +3609,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -45,6 +45,8 @@ async-trait = "0.1.89"
 jsonwebtoken = "9"
 cookie = "0.18"
 google-calendar3 = "6.0.0"
+claude-codes = "2.1.220"
+tempfile = "3.27.0"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/backend/src/auth/mod.rs
+++ b/crates/backend/src/auth/mod.rs
@@ -7,7 +7,7 @@
 //! - Email allowlist validation
 
 mod handlers;
-mod jwt;
+pub(crate) mod jwt;
 mod middleware;
 pub mod types;
 

--- a/crates/backend/src/bin/agent_cli.rs
+++ b/crates/backend/src/bin/agent_cli.rs
@@ -1,0 +1,266 @@
+//! CLI for triage agent sessions: the only way agents touch the system.
+//!
+//! Every call goes through the backend REST API so all agent activity is
+//! authenticated, validated, and audit-trailed as decisions. The session
+//! orchestrator drops `.agent-token` (a short-lived JWT) and `.agent-model`
+//! files in the session working directory; this binary picks them up.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use clap::{Parser, Subcommand};
+use reqwest::Client;
+use shared_types::{TriageDecideAction, TriageDecideRequest};
+use uuid::Uuid;
+
+#[derive(Parser)]
+#[command(name = "agent-cli")]
+#[command(about = "Triage agent interface to the agentive-inversion backend API")]
+struct Cli {
+    /// Backend API base URL
+    #[arg(long, default_value = "http://localhost:3000", env = "AGENT_API_URL")]
+    api_url: String,
+
+    /// Bearer token; falls back to ./.agent-token
+    #[arg(long, env = "AGENT_API_TOKEN")]
+    token: Option<String>,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Show the user's about-me document
+    AboutMe {
+        #[command(subcommand)]
+        command: AboutMeCommands,
+    },
+    /// Submit a triage disposition for an email
+    Decide {
+        #[command(subcommand)]
+        command: DecideCommands,
+    },
+    /// Show pipeline stage counts and health
+    Pipeline,
+}
+
+#[derive(Subcommand)]
+enum AboutMeCommands {
+    /// Print the about-me document content
+    Show,
+}
+
+#[derive(Subcommand)]
+enum DecideCommands {
+    /// Flag as probably-archivable (final call happens in a later pass)
+    ArchiveCandidate {
+        #[arg(long)]
+        email_id: Uuid,
+        #[arg(long)]
+        reasoning: String,
+    },
+    /// Archive now: label agent-archived and remove from inbox
+    Archive {
+        #[arg(long)]
+        email_id: Uuid,
+        #[arg(long)]
+        reasoning: String,
+    },
+    /// Deliberately leave in the inbox
+    Keep {
+        #[arg(long)]
+        email_id: Uuid,
+        #[arg(long)]
+        reasoning: String,
+    },
+    /// Propose a calendar event (goes to the user's review inbox)
+    Event {
+        #[arg(long)]
+        email_id: Uuid,
+        #[arg(long)]
+        summary: String,
+        /// RFC3339, e.g. 2026-08-09T18:00:00-07:00
+        #[arg(long)]
+        start: DateTime<Utc>,
+        /// RFC3339; defaults to one hour after start if omitted
+        #[arg(long)]
+        end: Option<DateTime<Utc>>,
+        #[arg(long)]
+        description: Option<String>,
+        #[arg(long)]
+        location: Option<String>,
+        #[arg(long)]
+        reasoning: String,
+    },
+    /// Propose a todo (goes to the user's review inbox)
+    Todo {
+        #[arg(long)]
+        email_id: Uuid,
+        #[arg(long)]
+        title: String,
+        #[arg(long)]
+        description: Option<String>,
+        /// RFC3339 due date
+        #[arg(long)]
+        due: Option<DateTime<Utc>>,
+        #[arg(long)]
+        reasoning: String,
+    },
+    /// Nothing actionable here
+    Ignore {
+        #[arg(long)]
+        email_id: Uuid,
+        #[arg(long)]
+        reasoning: String,
+    },
+    /// Send to the action queue for the deeper pass
+    QueueAction {
+        #[arg(long)]
+        email_id: Uuid,
+        #[arg(long)]
+        reasoning: String,
+    },
+}
+
+fn resolve_token(cli_token: Option<String>) -> Result<String> {
+    if let Some(t) = cli_token {
+        return Ok(t);
+    }
+    std::fs::read_to_string(".agent-token")
+        .map(|s| s.trim().to_string())
+        .context("No token: pass --token, set AGENT_API_TOKEN, or provide ./.agent-token")
+}
+
+fn session_model() -> Option<String> {
+    std::fs::read_to_string(".agent-model")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let token = resolve_token(cli.token)?;
+    let client = Client::new();
+    let base = cli.api_url.trim_end_matches('/');
+
+    match cli.command {
+        Commands::AboutMe {
+            command: AboutMeCommands::Show,
+        } => {
+            let resp = client
+                .get(format!("{base}/api/about-me"))
+                .bearer_auth(&token)
+                .send()
+                .await
+                .context("Request failed")?;
+            let status = resp.status();
+            let body: serde_json::Value = resp.json().await.context("Invalid response")?;
+            if !status.is_success() {
+                anyhow::bail!("API error {status}: {body}");
+            }
+            println!(
+                "{}",
+                body.get("content").and_then(|c| c.as_str()).unwrap_or("")
+            );
+        }
+
+        Commands::Pipeline => {
+            let resp = client
+                .get(format!("{base}/api/pipeline/stats"))
+                .bearer_auth(&token)
+                .send()
+                .await
+                .context("Request failed")?;
+            let status = resp.status();
+            let body: serde_json::Value = resp.json().await.context("Invalid response")?;
+            if !status.is_success() {
+                anyhow::bail!("API error {status}: {body}");
+            }
+            println!("{}", serde_json::to_string_pretty(&body)?);
+        }
+
+        Commands::Decide { command } => {
+            let (email_id, action, reasoning) = match command {
+                DecideCommands::ArchiveCandidate {
+                    email_id,
+                    reasoning,
+                } => (email_id, TriageDecideAction::ArchiveCandidate, reasoning),
+                DecideCommands::Archive {
+                    email_id,
+                    reasoning,
+                } => (email_id, TriageDecideAction::Archive, reasoning),
+                DecideCommands::Keep {
+                    email_id,
+                    reasoning,
+                } => (email_id, TriageDecideAction::Keep, reasoning),
+                DecideCommands::Ignore {
+                    email_id,
+                    reasoning,
+                } => (email_id, TriageDecideAction::Ignore, reasoning),
+                DecideCommands::QueueAction {
+                    email_id,
+                    reasoning,
+                } => (email_id, TriageDecideAction::QueueAction, reasoning),
+                DecideCommands::Event {
+                    email_id,
+                    summary,
+                    start,
+                    end,
+                    description,
+                    location,
+                    reasoning,
+                } => (
+                    email_id,
+                    TriageDecideAction::Event {
+                        summary,
+                        start,
+                        end: end.unwrap_or(start + chrono::Duration::hours(1)),
+                        description,
+                        location,
+                    },
+                    reasoning,
+                ),
+                DecideCommands::Todo {
+                    email_id,
+                    title,
+                    description,
+                    due,
+                    reasoning,
+                } => (
+                    email_id,
+                    TriageDecideAction::Todo {
+                        title,
+                        description,
+                        due_date: due,
+                    },
+                    reasoning,
+                ),
+            };
+
+            let req = TriageDecideRequest {
+                email_id,
+                action,
+                reasoning,
+                model: session_model(),
+            };
+
+            let resp = client
+                .post(format!("{base}/api/triage/decisions"))
+                .bearer_auth(&token)
+                .json(&req)
+                .send()
+                .await
+                .context("Request failed")?;
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            if !status.is_success() {
+                anyhow::bail!("API error {status}: {body}");
+            }
+            println!("{body}");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/backend/src/db.rs
+++ b/crates/backend/src/db.rs
@@ -343,6 +343,24 @@ pub mod emails {
         Ok(())
     }
 
+    /// List emails in a given triage state, oldest first
+    pub async fn list_by_triage_status(
+        conn: &mut AsyncPgConnection,
+        status: &str,
+        limit: i64,
+    ) -> anyhow::Result<Vec<Email>> {
+        use crate::schema::emails::dsl::*;
+
+        let items = emails
+            .filter(triage_status.eq(status))
+            .order_by(fetched_at.asc())
+            .limit(limit)
+            .load::<Email>(conn)
+            .await?;
+
+        Ok(items)
+    }
+
     /// List emails awaiting triage by the agent pipeline, oldest first
     pub async fn list_pending_triage(
         conn: &mut AsyncPgConnection,
@@ -1350,6 +1368,21 @@ pub mod google_accounts {
             .await?;
 
         Ok(accounts)
+    }
+
+    /// Look up an account by primary key
+    pub async fn get_by_id(
+        conn: &mut AsyncPgConnection,
+        account_id: Uuid,
+    ) -> anyhow::Result<GoogleAccount> {
+        use crate::schema::google_accounts::dsl::*;
+
+        let account = google_accounts
+            .filter(id.eq(account_id))
+            .first::<GoogleAccount>(conn)
+            .await?;
+
+        Ok(account)
     }
 
     /// Look up an account by email address

--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -10,8 +10,9 @@ use shared_types::{
     ChatHistoryQuery, ChatIntent, ChatMessageResponse, ChatResponse, CreateAgentDecisionRequest,
     CreateAgentRuleRequest, CreateCalendarEventRequest, CreateCalendarEventResponse,
     CreateCategoryRequest, CreateTodoRequest, DecisionStats, EmailListQuery, EmailResponse,
-    GoogleAccountResponse, RejectDecisionRequest, RuleListQuery, SendChatMessageRequest,
-    SuggestedAction, Todo, UpdateAboutMeRequest, UpdateAgentRuleRequest, UpdateCategoryRequest,
+    GoogleAccountResponse, PipelineStatsResponse, RejectDecisionRequest, RuleListQuery,
+    SendChatMessageRequest, SuggestedAction, Todo, TriageDecideRequest, TriageDecideResponse,
+    TriageStageCount, UpdateAboutMeRequest, UpdateAgentRuleRequest, UpdateCategoryRequest,
     UpdateTodoRequest,
 };
 use uuid::Uuid;
@@ -274,6 +275,38 @@ pub async fn create_calendar_event(
     }))
 }
 
+// Triage decision endpoint (called by agent-cli from agent sessions)
+pub async fn post_triage_decision(
+    State(state): State<AppState>,
+    Json(req): Json<TriageDecideRequest>,
+) -> ApiResult<Json<TriageDecideResponse>> {
+    let resp = crate::services::TriageService::apply(&state.pool, req)
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(Json(resp))
+}
+
+// Pipeline stats for the pipeline screen and monitoring (stable typed shape)
+pub async fn get_pipeline_stats(
+    State(state): State<AppState>,
+) -> ApiResult<Json<PipelineStatsResponse>> {
+    let mut conn = get_conn(&state.pool).await?;
+    let counts = emails::triage_status_counts(&mut conn).await?;
+
+    let health = state.triage_health.read().await.clone();
+
+    Ok(Json(PipelineStatsResponse {
+        mode: health.mode,
+        last_cycle_at: health.last_cycle_at,
+        last_cycle_error: health.last_cycle_error,
+        consecutive_failures: health.consecutive_failures,
+        stage_counts: counts
+            .into_iter()
+            .map(|(status, count)| TriageStageCount { status, count })
+            .collect(),
+    }))
+}
+
 // ============================================================================
 // Agent Decision handlers
 // ============================================================================
@@ -347,6 +380,19 @@ pub async fn approve_decision(
 ) -> ApiResult<Json<AgentDecisionResponse>> {
     let mut conn = state.pool.get().await?;
     let result = DecisionService::approve(&mut conn, id, payload.modifications).await?;
+    let is_calendar = result.decision.decision_type == "create_calendar_event";
+    drop(conn);
+
+    // Approving a gated calendar proposal executes the write
+    if is_calendar {
+        crate::services::TriageService::execute_calendar_decision(&state.pool, id)
+            .await
+            .map_err(ApiError::Internal)?;
+        let mut conn = state.pool.get().await?;
+        let refreshed = decisions::get_by_id(&mut conn, id).await?;
+        return Ok(Json(refreshed.into()));
+    }
+
     Ok(Json(result.decision.into()))
 }
 

--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -28,6 +28,7 @@ use auth::types::AuthConfig;
 pub struct AppState {
     pub pool: db::DbPool,
     pub auth_config: Arc<AuthConfig>,
+    pub triage_health: pollers::TriageHealth,
 }
 
 #[tokio::main]
@@ -52,15 +53,28 @@ async fn main() -> anyhow::Result<()> {
         auth_config.allowed_emails.len()
     );
 
+    let triage_health: pollers::TriageHealth = Arc::new(tokio::sync::RwLock::new(
+        pollers::TriageHealthState::default(),
+    ));
+
     let app_state = AppState {
         pool: pool.clone(),
-        auth_config,
+        auth_config: auth_config.clone(),
+        triage_health: triage_health.clone(),
     };
 
-    // Start email polling background task
+    // Start email polling background task (ingestion is never gated on triage)
     let email_poll_pool = pool.clone();
+    let email_poll_health = triage_health.clone();
     tokio::spawn(async move {
-        pollers::start_email_polling_task(email_poll_pool).await;
+        pollers::start_email_polling_task(email_poll_pool, email_poll_health).await;
+    });
+
+    // Start the agentic triage pipeline task
+    let triage_pool = pool.clone();
+    let triage_auth = auth_config.clone();
+    tokio::spawn(async move {
+        pollers::start_triage_task(triage_pool, triage_auth, triage_health).await;
     });
 
     // Start calendar polling background task (stub - not yet implemented)
@@ -116,6 +130,9 @@ async fn main() -> anyhow::Result<()> {
             "/rules/:id/toggle",
             post(handlers::toggle_agent_rule_active),
         )
+        // Triage pipeline routes (agent-cli + pipeline screen)
+        .route("/triage/decisions", post(handlers::post_triage_decision))
+        .route("/pipeline/stats", get(handlers::get_pipeline_stats))
         // Chat routes
         .route("/chat", post(handlers::send_chat_message))
         .route("/chat/history", get(handlers::get_chat_history))

--- a/crates/backend/src/pollers/email.rs
+++ b/crates/backend/src/pollers/email.rs
@@ -101,7 +101,7 @@ struct AccountState {
 }
 
 /// Start the email polling background task
-pub async fn start_email_polling_task(pool: DbPool) {
+pub async fn start_email_polling_task(pool: DbPool, triage_health: super::TriageHealth) {
     let config = EmailPollerConfig::from_env();
 
     tracing::info!(
@@ -114,7 +114,14 @@ pub async fn start_email_polling_task(pool: DbPool) {
     let mut account_states: HashMap<Uuid, AccountState> = HashMap::new();
 
     loop {
-        if let Err(e) = run_poll_cycle(&pool, &config, &mut rate_limiter, &mut account_states).await
+        if let Err(e) = run_poll_cycle(
+            &pool,
+            &config,
+            &mut rate_limiter,
+            &mut account_states,
+            &triage_health,
+        )
+        .await
         {
             tracing::error!("Email poll cycle failed: {}", e);
         }
@@ -128,6 +135,7 @@ async fn run_poll_cycle(
     config: &EmailPollerConfig,
     rate_limiter: &mut RateLimiter,
     account_states: &mut HashMap<Uuid, AccountState>,
+    triage_health: &super::TriageHealth,
 ) -> Result<()> {
     let mut conn = pool.get().await.context("Failed to get DB connection")?;
 
@@ -203,7 +211,11 @@ async fn run_poll_cycle(
         }
     }
 
-    // Process any unprocessed emails
+    // Keyword-heuristic fallback: only when the agentic pipeline is disabled.
+    // With triage active, classification happens in the triage task instead.
+    if triage_health.read().await.mode == "agentic" {
+        return Ok(());
+    }
     match processor::process_pending_emails(pool, config.max_process_per_cycle).await {
         Ok(stats) => {
             if stats.processed > 0 {

--- a/crates/backend/src/pollers/mod.rs
+++ b/crates/backend/src/pollers/mod.rs
@@ -5,8 +5,10 @@
 
 pub mod calendar;
 pub mod email;
-mod gmail_client;
+pub mod gmail_client;
 mod processor;
+pub mod triage;
 
 pub use calendar::start_calendar_polling_task;
 pub use email::start_email_polling_task;
+pub use triage::{start_triage_task, TriageHealth, TriageHealthState};

--- a/crates/backend/src/pollers/triage.rs
+++ b/crates/backend/src/pollers/triage.rs
@@ -1,0 +1,393 @@
+//! Multi-model agentic triage pipeline.
+//!
+//! Runs as its own background task, decoupled from email ingestion — a triage
+//! failure must never stop mail from landing in the database (emails simply
+//! stay `pending` and the queue self-drains when triage recovers).
+//!
+//! Per cycle, three stages run as Claude Code sessions (via the claude-codes
+//! crate), each restricted to the Read tool and the `agent-cli` binary, which
+//! talks to our own REST API:
+//!   1. screening (Haiku): pending → archive_candidate / event / action / keep
+//!   2. archive determinations (Sonnet): archive_candidate → archived / kept
+//!   3. action pass (Opus + about-me doc): action_queued → todo proposals
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use claude_codes::{AsyncClient, ClaudeCliBuilder, PermissionMode};
+use serde::Serialize;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+
+use crate::auth::types::AuthConfig;
+use crate::db::{self, DbPool};
+use crate::services::triage::gmail_permalink;
+
+/// Shared triage health state, exposed via /api/pipeline/stats
+#[derive(Debug, Clone)]
+pub struct TriageHealthState {
+    pub mode: String,
+    pub last_cycle_at: Option<DateTime<Utc>>,
+    pub last_cycle_error: Option<String>,
+    pub consecutive_failures: i32,
+}
+
+impl Default for TriageHealthState {
+    fn default() -> Self {
+        Self {
+            mode: "starting".to_string(),
+            last_cycle_at: None,
+            last_cycle_error: None,
+            consecutive_failures: 0,
+        }
+    }
+}
+
+pub type TriageHealth = Arc<RwLock<TriageHealthState>>;
+
+#[derive(Debug, Clone)]
+pub struct TriageConfig {
+    pub poll_interval: Duration,
+    pub batch_size: i64,
+    pub screen_model: String,
+    pub archive_model: String,
+    pub action_model: String,
+    pub session_timeout: Duration,
+}
+
+impl TriageConfig {
+    pub fn from_env() -> Self {
+        let env_or =
+            |key: &str, default: &str| std::env::var(key).unwrap_or_else(|_| default.to_string());
+        Self {
+            poll_interval: Duration::from_secs(
+                env_or("TRIAGE_POLL_INTERVAL_SECS", "300")
+                    .parse()
+                    .unwrap_or(300),
+            ),
+            batch_size: env_or("TRIAGE_BATCH_SIZE", "20").parse().unwrap_or(20),
+            screen_model: env_or("TRIAGE_SCREEN_MODEL", "claude-haiku-4-5"),
+            archive_model: env_or("TRIAGE_ARCHIVE_MODEL", "claude-sonnet-4-5"),
+            action_model: env_or("TRIAGE_ACTION_MODEL", "claude-opus-4-8"),
+            session_timeout: Duration::from_secs(
+                env_or("TRIAGE_SESSION_TIMEOUT_SECS", "600")
+                    .parse()
+                    .unwrap_or(600),
+            ),
+        }
+    }
+}
+
+/// Email fields handed to agent sessions in the datafile
+#[derive(Debug, Serialize)]
+struct EmailForAgent {
+    id: uuid::Uuid,
+    account_email: String,
+    from_address: String,
+    from_name: Option<String>,
+    subject: String,
+    received_at: DateTime<Utc>,
+    snippet: Option<String>,
+    body_text: Option<String>,
+    gmail_link: String,
+}
+
+const BODY_TRUNCATE_CHARS: usize = 4000;
+
+const SCREEN_INSTRUCTIONS: &str = r#"You are the screening stage of an email triage pipeline.
+
+Read ./emails.json (use the Read tool). It contains a JSON array of emails.
+For EVERY email in the file, make exactly one disposition by running the
+agent-cli command via Bash. Do not skip any email. Do not take any other action.
+
+Dispositions:
+- Newsletter, promotion, notification, or automated mail with no action needed:
+  agent-cli decide archive-candidate --email-id <id> --reasoning "<why>"
+- Contains a real-world event with a concrete date/time the user could attend
+  (invitation, appointment, meetup, wedding, show, deadline-as-event):
+  agent-cli decide event --email-id <id> --summary "<title>" --start <rfc3339> --end <rfc3339> [--location "<loc>"] [--description "<details>"] --reasoning "<why>"
+  If the timezone is unclear, assume America/Los_Angeles. If no end time is
+  given, assume one hour after the start.
+- Requires the user to act, reply, decide, or follow up:
+  agent-cli decide queue-action --email-id <id> --reasoning "<why>"
+- Personal or potentially important, but nothing to do right now:
+  agent-cli decide keep --email-id <id> --reasoning "<why>"
+
+Be decisive and fast. One agent-cli call per email. When finished, reply with
+a one-line summary of counts per category."#;
+
+const ARCHIVE_INSTRUCTIONS: &str = r#"You are the archive-determination stage of an email triage pipeline.
+
+Read ./emails.json (use the Read tool). Each email was flagged by a screening
+pass as probably archivable. Make the FINAL call for every email by running
+agent-cli via Bash:
+
+- Confirm archive (removes it from the inbox, tagged 'agent-archived',
+  recoverable): agent-cli decide archive --email-id <id> --reasoning "<why>"
+- Not sure, or it might matter to the user: agent-cli decide keep --email-id <id> --reasoning "<why>"
+
+Be conservative: personal correspondence, money, legal, medical, childcare,
+travel, or anything that reads like a human wrote it to the user specifically
+should be kept. Bulk mail, marketing, and automated notifications with no
+action should be archived. One call per email; do not skip any. Finish with a
+one-line summary."#;
+
+const ACTION_INSTRUCTIONS: &str = r#"You are the action stage of an email triage pipeline: you decide what belongs
+on the user's todo list.
+
+First run: agent-cli about-me show
+That document describes who the user is and what matters to them. Use it to
+judge importance, urgency, and how to phrase todos.
+
+Then read ./emails.json (use the Read tool). Every email was flagged as
+needing action. For each one, run exactly one agent-cli command via Bash:
+
+- Propose a todo (goes to the user's review inbox):
+  agent-cli decide todo --email-id <id> --title "<concrete next action>" [--description "<context>"] [--due <rfc3339>] --reasoning "<why this matters, referencing the about-me context where relevant>"
+- On reflection nothing is actually needed:
+  agent-cli decide ignore --email-id <id> --reasoning "<why>"
+
+Todo titles should be concrete next actions ("Reply to adjuster with repair
+estimate"), not vague ("Handle insurance email"). Extract real deadlines into
+--due. One call per email; do not skip any. Finish with a one-line summary."#;
+
+/// Start the triage background task. Never blocks ingestion; failures leave
+/// emails pending for the next cycle.
+pub async fn start_triage_task(pool: DbPool, auth_config: Arc<AuthConfig>, health: TriageHealth) {
+    let config = TriageConfig::from_env();
+
+    // Initial mode detection with explicit, greppable logging
+    match detect_mode().await {
+        Ok(()) => {
+            tracing::info!(
+                "Email triage mode: agentic (screen={}, archive={}, action={})",
+                config.screen_model,
+                config.archive_model,
+                config.action_model
+            );
+            health.write().await.mode = "agentic".to_string();
+        }
+        Err(reason) => {
+            tracing::warn!("Email triage mode: disabled ({reason})");
+            health.write().await.mode = "disabled".to_string();
+        }
+    }
+
+    loop {
+        // Re-detect each cycle so adding a key/binary recovers without restart
+        match detect_mode().await {
+            Ok(()) => {
+                {
+                    let mut h = health.write().await;
+                    if h.mode != "agentic" {
+                        tracing::info!("Email triage mode: agentic (recovered)");
+                    }
+                    h.mode = "agentic".to_string();
+                }
+
+                match run_cycle(&pool, &auth_config, &config).await {
+                    Ok(worked) => {
+                        let mut h = health.write().await;
+                        h.last_cycle_at = Some(Utc::now());
+                        h.last_cycle_error = None;
+                        h.consecutive_failures = 0;
+                        drop(h);
+                        if worked > 0 {
+                            tracing::info!("Triage cycle processed {} emails", worked);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Triage cycle failed: {:#}", e);
+                        let mut h = health.write().await;
+                        h.last_cycle_at = Some(Utc::now());
+                        h.last_cycle_error = Some(format!("{e:#}"));
+                        h.consecutive_failures += 1;
+                    }
+                }
+            }
+            Err(reason) => {
+                let mut h = health.write().await;
+                if h.mode != "disabled" {
+                    tracing::warn!("Email triage mode: disabled ({reason})");
+                }
+                h.mode = "disabled".to_string();
+            }
+        }
+
+        tokio::time::sleep(config.poll_interval).await;
+    }
+}
+
+/// Check the runtime prerequisites for agentic triage
+async fn detect_mode() -> Result<(), String> {
+    if std::env::var("ANTHROPIC_API_KEY").is_err() {
+        return Err("ANTHROPIC_API_KEY not set".to_string());
+    }
+
+    match tokio::process::Command::new("claude")
+        .arg("--version")
+        .output()
+        .await
+    {
+        Ok(out) if out.status.success() => Ok(()),
+        Ok(_) => Err("claude binary exited non-zero".to_string()),
+        Err(e) => Err(format!("claude binary not found: {e}")),
+    }
+}
+
+/// Run one full triage cycle (all three stages). Returns emails touched.
+async fn run_cycle(
+    pool: &DbPool,
+    auth_config: &AuthConfig,
+    config: &TriageConfig,
+) -> Result<usize> {
+    let service_email = auth_config
+        .allowed_emails
+        .first()
+        .context("ALLOWED_EMAILS is empty; cannot mint agent token")?;
+    let token = crate::auth::jwt::create_token(
+        auth_config,
+        service_email,
+        Some("triage-agent".to_string()),
+    )
+    .context("Failed to mint agent session token")?;
+
+    let mut total = 0;
+
+    // Stage 1: screening (Haiku)
+    let pending = load_stage_emails(pool, "pending", config.batch_size).await?;
+    if !pending.is_empty() {
+        total += pending.len();
+        run_stage(
+            &config.screen_model,
+            SCREEN_INSTRUCTIONS,
+            &pending,
+            &token,
+            config.session_timeout,
+        )
+        .await
+        .context("Screening stage failed")?;
+    }
+
+    // Stage 2: archive determinations (Sonnet)
+    let candidates = load_stage_emails(pool, "archive_candidate", config.batch_size).await?;
+    if !candidates.is_empty() {
+        run_stage(
+            &config.archive_model,
+            ARCHIVE_INSTRUCTIONS,
+            &candidates,
+            &token,
+            config.session_timeout,
+        )
+        .await
+        .context("Archive determination stage failed")?;
+    }
+
+    // Stage 3: action pass (Opus + about-me)
+    let actions = load_stage_emails(pool, "action_queued", config.batch_size).await?;
+    if !actions.is_empty() {
+        run_stage(
+            &config.action_model,
+            ACTION_INSTRUCTIONS,
+            &actions,
+            &token,
+            config.session_timeout,
+        )
+        .await
+        .context("Action stage failed")?;
+    }
+
+    Ok(total)
+}
+
+async fn load_stage_emails(pool: &DbPool, status: &str, limit: i64) -> Result<Vec<EmailForAgent>> {
+    let mut conn = pool.get().await.context("Failed to get DB connection")?;
+    let emails = db::emails::list_by_triage_status(&mut conn, status, limit).await?;
+    let accounts = db::google_accounts::list_all(&mut conn).await?;
+
+    let account_email = |id: uuid::Uuid| {
+        accounts
+            .iter()
+            .find(|a| a.id == id)
+            .map(|a| a.email.clone())
+            .unwrap_or_default()
+    };
+
+    Ok(emails
+        .into_iter()
+        .map(|e| {
+            let acct = account_email(e.account_id);
+            let gmail_link = gmail_permalink(&acct, &e.gmail_id);
+            EmailForAgent {
+                id: e.id,
+                account_email: acct,
+                from_address: e.from_address,
+                from_name: e.from_name,
+                subject: e.subject,
+                received_at: e.received_at,
+                snippet: e.snippet,
+                body_text: e
+                    .body_text
+                    .map(|b| b.chars().take(BODY_TRUNCATE_CHARS).collect()),
+                gmail_link,
+            }
+        })
+        .collect())
+}
+
+/// Run one agent session over a batch of emails
+async fn run_stage(
+    model: &str,
+    instructions: &str,
+    emails: &[EmailForAgent],
+    token: &str,
+    timeout: Duration,
+) -> Result<()> {
+    let workdir = tempfile::tempdir().context("Failed to create session workdir")?;
+
+    std::fs::write(
+        workdir.path().join("emails.json"),
+        serde_json::to_vec_pretty(emails)?,
+    )
+    .context("Failed to write datafile")?;
+    std::fs::write(workdir.path().join(".agent-token"), token)
+        .context("Failed to write agent token")?;
+    std::fs::write(workdir.path().join(".agent-model"), model)
+        .context("Failed to write agent model tag")?;
+
+    let builder = ClaudeCliBuilder::new()
+        .model(model)
+        .working_directory(workdir.path())
+        .allowed_tools(["Read", "Bash(agent-cli:*)"])
+        .permission_mode(PermissionMode::DontAsk);
+
+    let mut client = AsyncClient::from_builder(builder)
+        .await
+        .context("Failed to start claude session")?;
+
+    let prompt = format!(
+        "{instructions}\n\nThere are {} emails in ./emails.json.",
+        emails.len()
+    );
+
+    let outputs = tokio::time::timeout(timeout, client.query(&prompt))
+        .await
+        .context("Agent session timed out")?
+        .context("Agent session failed")?;
+
+    for output in &outputs {
+        if let claude_codes::ClaudeOutput::Result(r) = output {
+            if r.is_error {
+                anyhow::bail!("Agent session ended in error state");
+            }
+            tracing::info!(
+                "Triage session complete: model={model} turns={} emails={}",
+                r.num_turns,
+                emails.len()
+            );
+        }
+    }
+
+    client.shutdown().await.ok();
+    Ok(())
+}

--- a/crates/backend/src/services/mod.rs
+++ b/crates/backend/src/services/mod.rs
@@ -1,5 +1,7 @@
 //! Business logic services separated from HTTP handling.
 
 pub mod decision;
+pub mod triage;
 
 pub use decision::DecisionService;
+pub use triage::TriageService;

--- a/crates/backend/src/services/triage.rs
+++ b/crates/backend/src/services/triage.rs
@@ -1,0 +1,298 @@
+//! Applies triage dispositions submitted by agent sessions via agent-cli.
+//!
+//! Policy lives here, server-side, not in the agents: archiving auto-executes
+//! (reversible — labeled and searchable in Gmail), while calendar events and
+//! todos land as proposed decisions gated on human approval.
+
+use anyhow::{Context, Result};
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::db::{self, DbPool};
+use crate::pollers::gmail_client::GmailClient;
+use shared_types::{
+    DecisionStatus, DecisionType, ProposedCalendarEventAction, ProposedTodoAction,
+    TriageDecideAction, TriageDecideRequest, TriageDecideResponse,
+};
+
+/// Gmail label applied to everything the agent archives
+pub const AGENT_ARCHIVE_LABEL: &str = "agent-archived";
+
+/// Default calendar for agent-created events
+pub const AGENT_CALENDAR_NAME: &str = "Agent";
+
+/// Permalink to a message in the account's Gmail UI
+pub fn gmail_permalink(account_email: &str, gmail_id: &str) -> String {
+    format!("https://mail.google.com/mail/u/{account_email}/#all/{gmail_id}")
+}
+
+pub struct TriageService;
+
+impl TriageService {
+    /// Apply one agent disposition. Returns what happened so the agent's CLI
+    /// call gets a truthful, machine-readable answer.
+    pub async fn apply(pool: &DbPool, req: TriageDecideRequest) -> Result<TriageDecideResponse> {
+        let mut conn = pool.get().await.context("Failed to get DB connection")?;
+
+        let email = db::emails::get_by_id(&mut conn, req.email_id)
+            .await
+            .context("Email not found")?;
+
+        let reasoning_details = req
+            .model
+            .as_ref()
+            .map(|m| json!({ "llm_analysis": format!("model: {m}") }).to_string());
+
+        match req.action {
+            TriageDecideAction::ArchiveCandidate => {
+                db::emails::set_triage_status(&mut conn, email.id, "archive_candidate").await?;
+                Ok(TriageDecideResponse {
+                    email_id: email.id,
+                    decision_id: None,
+                    triage_status: "archive_candidate".to_string(),
+                    executed: false,
+                })
+            }
+
+            TriageDecideAction::Keep => {
+                db::emails::set_triage_status(&mut conn, email.id, "kept").await?;
+                db::emails::mark_processed(&mut conn, email.id).await?;
+                Ok(TriageDecideResponse {
+                    email_id: email.id,
+                    decision_id: None,
+                    triage_status: "kept".to_string(),
+                    executed: false,
+                })
+            }
+
+            TriageDecideAction::Ignore => {
+                let decision_id = db::decisions::create_with_status(
+                    &mut conn,
+                    "email",
+                    Some(email.id),
+                    Some(&email.gmail_id),
+                    DecisionType::Ignore.as_str(),
+                    "{}",
+                    &req.reasoning,
+                    reasoning_details.as_deref(),
+                    0.9,
+                    DecisionStatus::AutoApproved.as_str(),
+                    None,
+                )
+                .await?;
+                db::emails::set_triage_status(&mut conn, email.id, "ignored").await?;
+                db::emails::mark_processed(&mut conn, email.id).await?;
+                Ok(TriageDecideResponse {
+                    email_id: email.id,
+                    decision_id: Some(decision_id),
+                    triage_status: "ignored".to_string(),
+                    executed: false,
+                })
+            }
+
+            TriageDecideAction::QueueAction => {
+                db::emails::set_triage_status(&mut conn, email.id, "action_queued").await?;
+                Ok(TriageDecideResponse {
+                    email_id: email.id,
+                    decision_id: None,
+                    triage_status: "action_queued".to_string(),
+                    executed: false,
+                })
+            }
+
+            TriageDecideAction::Archive => {
+                let account = db::google_accounts::get_by_id(&mut conn, email.account_id)
+                    .await
+                    .context("Account for email not found")?;
+
+                let decision_id = db::decisions::create_with_status(
+                    &mut conn,
+                    "email",
+                    Some(email.id),
+                    Some(&email.gmail_id),
+                    DecisionType::Archive.as_str(),
+                    "{}",
+                    &req.reasoning,
+                    reasoning_details.as_deref(),
+                    0.9,
+                    DecisionStatus::AutoApproved.as_str(),
+                    None,
+                )
+                .await?;
+
+                // Execute against Gmail. Failure leaves the email pending so a
+                // later cycle retries; the decision records the failure.
+                let gmail_result = async {
+                    let client = GmailClient::from_account(&account).await?;
+                    let label_id = client.ensure_label(AGENT_ARCHIVE_LABEL).await?;
+                    client.archive_with_label(&email.gmail_id, &label_id).await
+                }
+                .await;
+
+                match gmail_result {
+                    Ok(()) => {
+                        db::emails::mark_archived_in_gmail(&mut conn, email.id).await?;
+                        db::emails::set_triage_status(&mut conn, email.id, "archived").await?;
+                        db::emails::mark_processed(&mut conn, email.id).await?;
+                        db::decisions::mark_executed(&mut conn, decision_id).await?;
+                        Ok(TriageDecideResponse {
+                            email_id: email.id,
+                            decision_id: Some(decision_id),
+                            triage_status: "archived".to_string(),
+                            executed: true,
+                        })
+                    }
+                    Err(e) => {
+                        db::decisions::mark_failed(&mut conn, decision_id, "gmail archive failed")
+                            .await?;
+                        Err(e.context("Gmail archive failed; email left for retry"))
+                    }
+                }
+            }
+
+            TriageDecideAction::Event {
+                summary,
+                start,
+                end,
+                description,
+                location,
+            } => {
+                let account = db::google_accounts::get_by_id(&mut conn, email.account_id)
+                    .await
+                    .context("Account for email not found")?;
+
+                let action = ProposedCalendarEventAction {
+                    account_email: account.email.clone(),
+                    summary,
+                    description,
+                    location,
+                    start,
+                    end,
+                    email_link: Some(gmail_permalink(&account.email, &email.gmail_id)),
+                    calendar_name: Some(AGENT_CALENDAR_NAME.to_string()),
+                };
+
+                let decision_id = db::decisions::create_with_status(
+                    &mut conn,
+                    "email",
+                    Some(email.id),
+                    Some(&email.gmail_id),
+                    DecisionType::CreateCalendarEvent.as_str(),
+                    &serde_json::to_string(&action)?,
+                    &req.reasoning,
+                    reasoning_details.as_deref(),
+                    0.8,
+                    DecisionStatus::Proposed.as_str(),
+                    None,
+                )
+                .await?;
+                db::emails::set_triage_status(&mut conn, email.id, "event_proposed").await?;
+                db::emails::mark_processed(&mut conn, email.id).await?;
+                Ok(TriageDecideResponse {
+                    email_id: email.id,
+                    decision_id: Some(decision_id),
+                    triage_status: "event_proposed".to_string(),
+                    executed: false,
+                })
+            }
+
+            TriageDecideAction::Todo {
+                title,
+                description,
+                due_date,
+            } => {
+                let action = ProposedTodoAction {
+                    todo_title: title,
+                    todo_description: description,
+                    due_date,
+                    category_id: None,
+                    priority: None,
+                };
+
+                let decision_id = db::decisions::create_with_status(
+                    &mut conn,
+                    "email",
+                    Some(email.id),
+                    Some(&email.gmail_id),
+                    DecisionType::CreateTodo.as_str(),
+                    &serde_json::to_string(&action)?,
+                    &req.reasoning,
+                    reasoning_details.as_deref(),
+                    0.8,
+                    DecisionStatus::Proposed.as_str(),
+                    None,
+                )
+                .await?;
+                db::emails::set_triage_status(&mut conn, email.id, "todo_proposed").await?;
+                db::emails::mark_processed(&mut conn, email.id).await?;
+                Ok(TriageDecideResponse {
+                    email_id: email.id,
+                    decision_id: Some(decision_id),
+                    triage_status: "todo_proposed".to_string(),
+                    executed: false,
+                })
+            }
+        }
+    }
+
+    /// Execute an approved calendar-event decision (the gated half of the
+    /// event flow). Returns the created event's ID.
+    pub async fn execute_calendar_decision(pool: &DbPool, decision_id: Uuid) -> Result<String> {
+        use crate::calendar_writer::{CalendarWriter, NewCalendarEvent};
+
+        let mut conn = pool.get().await.context("Failed to get DB connection")?;
+
+        let decision = db::decisions::get_by_id(&mut conn, decision_id)
+            .await
+            .context("Decision not found")?;
+
+        let action: ProposedCalendarEventAction =
+            serde_json::from_str(&decision.proposed_action)
+                .context("Decision proposed_action is not a calendar event")?;
+
+        let account = db::google_accounts::get_by_email(&mut conn, &action.account_email)
+            .await?
+            .context("Account for calendar decision not found")?;
+        drop(conn);
+
+        let writer = CalendarWriter::from_account(&account).await?;
+        let calendar_name = action
+            .calendar_name
+            .as_deref()
+            .unwrap_or(AGENT_CALENDAR_NAME);
+        let calendar_id = writer.ensure_calendar(calendar_name).await?;
+
+        let created = writer
+            .create_event(
+                &calendar_id,
+                NewCalendarEvent {
+                    summary: action.summary,
+                    description: action.description,
+                    location: action.location,
+                    start: action.start,
+                    end: action.end,
+                    email_link: action.email_link,
+                },
+            )
+            .await?;
+
+        let mut conn = pool.get().await.context("Failed to get DB connection")?;
+        db::decisions::mark_executed(&mut conn, decision_id).await?;
+
+        Ok(created.google_event_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permalink_targets_the_account_mailbox() {
+        let link = gmail_permalink("matt@exclosure.io", "18c2f0a");
+        assert_eq!(
+            link,
+            "https://mail.google.com/mail/u/matt@exclosure.io/#all/18c2f0a"
+        );
+    }
+}

--- a/crates/shared-types/src/lib.rs
+++ b/crates/shared-types/src/lib.rs
@@ -330,6 +330,89 @@ pub struct CreateCalendarEventResponse {
     pub calendar_id: String,
 }
 
+/// Calendar event proposed by the triage agent (stored as a gated decision's
+/// proposed_action; executed on approval)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposedCalendarEventAction {
+    pub account_email: String,
+    pub summary: String,
+    pub description: Option<String>,
+    pub location: Option<String>,
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    pub email_link: Option<String>,
+    pub calendar_name: Option<String>,
+}
+
+/// Disposition submitted by a triage agent session for one email
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TriageDecideAction {
+    /// Screening pass flagged this as probably-archivable (final call is a
+    /// later determination pass)
+    ArchiveCandidate,
+    /// Archive now: label agent-archived and remove from inbox (auto-executed)
+    Archive,
+    /// Deliberately leave in the inbox
+    Keep,
+    /// Propose a calendar event (gated: lands in the decision inbox)
+    Event {
+        summary: String,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        description: Option<String>,
+        location: Option<String>,
+    },
+    /// Propose a todo (gated: lands in the decision inbox)
+    Todo {
+        title: String,
+        description: Option<String>,
+        due_date: Option<DateTime<Utc>>,
+    },
+    /// Nothing actionable here
+    Ignore,
+    /// Send to the action queue for the deeper (Opus) pass
+    QueueAction,
+}
+
+/// Request body for POST /api/triage/decisions (sent by agent-cli)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriageDecideRequest {
+    pub email_id: Uuid,
+    pub action: TriageDecideAction,
+    pub reasoning: String,
+    /// Model that made this call, for the audit trail
+    pub model: Option<String>,
+}
+
+/// Response for a triage disposition
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriageDecideResponse {
+    pub email_id: Uuid,
+    pub decision_id: Option<Uuid>,
+    pub triage_status: String,
+    /// Whether a side effect (e.g. Gmail archive) already ran
+    pub executed: bool,
+}
+
+/// One triage_status bucket count for the pipeline display
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TriageStageCount {
+    pub status: String,
+    pub count: i64,
+}
+
+/// Typed pipeline/triage health status (stable shape; consumed by monitoring)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PipelineStatsResponse {
+    /// "agentic" or "disabled" (no API key / claude binary)
+    pub mode: String,
+    pub last_cycle_at: Option<DateTime<Utc>>,
+    pub last_cycle_error: Option<String>,
+    pub consecutive_failures: i32,
+    pub stage_counts: Vec<TriageStageCount>,
+}
+
 /// Query parameters for listing emails
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct EmailListQuery {
@@ -383,6 +466,7 @@ pub enum DecisionType {
     Defer,
     Categorize,
     SetDueDate,
+    CreateCalendarEvent,
 }
 
 impl DecisionType {
@@ -394,6 +478,7 @@ impl DecisionType {
             DecisionType::Defer => "defer",
             DecisionType::Categorize => "categorize",
             DecisionType::SetDueDate => "set_due_date",
+            DecisionType::CreateCalendarEvent => "create_calendar_event",
         }
     }
 
@@ -405,6 +490,7 @@ impl DecisionType {
             "defer" => Some(DecisionType::Defer),
             "categorize" => Some(DecisionType::Categorize),
             "set_due_date" => Some(DecisionType::SetDueDate),
+            "create_calendar_event" => Some(DecisionType::CreateCalendarEvent),
             _ => None,
         }
     }
@@ -1509,4 +1595,44 @@ pub struct AuthUserResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoginInitResponse {
     pub auth_url: String,
+}
+
+#[cfg(test)]
+mod triage_type_tests {
+    use super::*;
+
+    #[test]
+    fn triage_action_wire_format_is_stable() {
+        let json = serde_json::to_value(&TriageDecideAction::ArchiveCandidate).unwrap();
+        assert_eq!(json["type"], "archive_candidate");
+
+        let event = TriageDecideAction::Event {
+            summary: "Dinner".to_string(),
+            start: "2026-08-09T18:00:00Z".parse().unwrap(),
+            end: "2026-08-09T19:00:00Z".parse().unwrap(),
+            description: None,
+            location: Some("SF".to_string()),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "event");
+        assert_eq!(json["summary"], "Dinner");
+
+        let parsed: TriageDecideAction = serde_json::from_str(
+            r#"{"type":"todo","title":"Reply","description":null,"due_date":null}"#,
+        )
+        .unwrap();
+        assert!(matches!(parsed, TriageDecideAction::Todo { .. }));
+    }
+
+    #[test]
+    fn calendar_decision_type_round_trips() {
+        assert_eq!(
+            DecisionType::CreateCalendarEvent.as_str(),
+            "create_calendar_event"
+        );
+        assert_eq!(
+            DecisionType::parse("create_calendar_event"),
+            Some(DecisionType::CreateCalendarEvent)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Replaces the keyword classifier with the agentic triage pipeline (PR 2 of 3). Emails now flow through three Claude Code sessions driven by the `claude-codes` crate, each sandboxed to `Read` + `Bash(agent-cli:*)`:

1. **Screening — `claude-haiku-4-5`**: every pending email → `archive-candidate` / `event` proposal / `queue-action` / `keep`
2. **Archive determinations — `claude-sonnet-4-5`**: final call on candidates; confirmed archives **auto-execute** (Gmail label `agent-archived` + remove from INBOX — reversible by design)
3. **Action pass — `claude-opus-4-8`**: reads the about-me document first, then turns queued emails into concrete todo proposals (gated in the decision inbox)

**Agent interface is REST-only.** Sessions get a datafile (`emails.json`) plus a short-lived JWT (minted per cycle, dropped as `.agent-token` in the session workdir), and act exclusively through the new `agent-cli` binary → `POST /api/triage/decisions`. Every disposition becomes an audited `agent_decisions` row; policy (what auto-executes vs what gates) lives server-side in `TriageService`, not in prompts.

**Calendar flow**: agents *propose* events; approving the decision in the inbox executes the write to the "Agent" calendar (wired into `approve_decision`), with the Gmail permalink attached.

**Invariants held:**
- Ingestion is never gated on triage: the pipeline is its own tokio task; failures leave emails `pending` (lossless, self-draining) and never touch the Gmail-sync health counters
- Triage mode logged explicitly at boot and exposed in the typed `GET /api/pipeline/stats` shape (`mode`, `last_cycle_at`, `last_cycle_error`, `consecutive_failures`, per-stage counts) for monitoring
- No API key / no `claude` binary → mode `disabled`, keyword heuristic keeps running as fallback, and the pipeline recovers without restart once prerequisites appear

## Deploy notes (PR C completes this)

Production stays in `disabled`/keyword mode until the image ships the `claude` binary + `agent-cli` and `ANTHROPIC_API_KEY` is injected — coordinated with infrastructure. The stored email corpus comparison vs the 13/100 keyword baseline runs at that point, before relying on the pipeline.

## Testing

- `cargo test --workspace` (new: wire-format stability for `TriageDecideAction`, `create_calendar_event` round-trip, Gmail permalink), clippy `--all-features` zero warnings, fmt clean
- Live agent sessions are exercised post-deploy (require `claude` + API key + DB); cycle logic is defensive: per-stage timeouts, error isolation, batch caps