### PR TITLE
Pipeline screen, about-me editor, and triage deploy pieces

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -124,6 +124,15 @@ cargo clippy --workspace         # Lint code
 - Write directly to database
 - Spawned from `crates/backend/src/main.rs`
 
+### Agentic Triage Pipeline
+- Lives in `crates/backend/src/pollers/triage.rs` (orchestrator) + `services/triage.rs` (policy)
+- Three Claude Code sessions per cycle via the `claude-codes` crate: Haiku screening, Sonnet 4.5 archive determinations (auto-executed, Gmail label `agent-archived`), Opus 4.8 action pass (reads about_me, proposes todos)
+- Agents act ONLY through the `agent-cli` binary -> REST API (`POST /api/triage/decisions`); never give agents direct DB access
+- INVARIANT: ingestion is never gated on triage; Anthropic/API failures must never touch Gmail-sync health or backoff (separate failure domains)
+- Calendar writes are gated: agents propose `create_calendar_event` decisions; approval executes to the "Agent" calendar
+- Requires `claude` binary + `ANTHROPIC_API_KEY` in the container; otherwise mode=disabled and the keyword heuristic fallback runs
+- Do not change TriageDecideAction / PipelineStatsResponse wire shapes casually - agent-cli and monitoring depend on them
+
 ## Environment Variables
 
 Required variables (see `.env.example`):

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -42,8 +42,8 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build release binary
-        run: cargo build --release --bin backend
+      - name: Build release binaries
+        run: cargo build --release --bin backend --bin agent-cli
 
       - name: Install Trunk
         run: wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.21.14/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf- -C ~/.cargo/bin
@@ -55,7 +55,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: backend-binary
-          path: target/release/backend
+          path: |
+            target/release/backend
+            target/release/agent-cli
           retention-days: 1
 
       - name: Upload frontend dist
@@ -87,8 +89,8 @@ jobs:
           name: frontend-dist
           path: crates/frontend/dist
 
-      - name: Make binary executable
-        run: chmod +x target/release/backend
+      - name: Make binaries executable
+        run: chmod +x target/release/backend target/release/agent-cli
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@
 #
 # Optional environment variables:
 #   RUST_LOG              - Log level (default: info)
+#   ANTHROPIC_API_KEY     - Enables the agentic triage pipeline (else keyword fallback)
 #   FRONTEND_DIR          - Frontend files path (default: /app/frontend/dist)
 #   CORS_ALLOWED_ORIGINS  - Comma-separated allowed CORS origins
 
@@ -20,10 +21,20 @@ RUN apt-get update && \
     apt-get install -y libpq5 postgresql-client ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
 
+# Node.js + Claude Code CLI for the agentic triage pipeline. Without these
+# (or without ANTHROPIC_API_KEY) the backend runs in keyword-fallback mode.
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g @anthropic-ai/claude-code && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Copy pre-built backend binary
 COPY ./target/release/backend /app/backend
+
+# Agent CLI used by triage agent sessions (must be on PATH)
+COPY ./target/release/agent-cli /usr/local/bin/agent-cli
 
 # Copy pre-built frontend dist
 COPY ./crates/frontend/dist /app/frontend/dist

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -50,3 +50,7 @@ tempfile = "3.27.0"
 
 [dev-dependencies]
 tokio-test = "0.4"
+
+[[bin]]
+name = "agent-cli"
+path = "src/bin/agent_cli.rs"

--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -1,10 +1,11 @@
 use gloo_net::http::Request;
 use shared_types::{
-    AgentDecisionResponse, ApproveDecisionRequest, AuthUserResponse, BatchApproveDecisionsRequest,
-    BatchRejectDecisionsRequest, CalendarEventResponse, Category, ChatMessageResponse,
-    ChatResponse, CreateTodoRequest, DecisionStats, EmailResponse, GoogleAccountResponse,
-    LoginInitResponse, ProposedTodoAction, RejectDecisionRequest, SendChatMessageRequest,
-    SuggestedAction, Todo, UpdateTodoRequest,
+    AboutMeResponse, AgentDecisionResponse, ApproveDecisionRequest, AuthUserResponse,
+    BatchApproveDecisionsRequest, BatchRejectDecisionsRequest, CalendarEventResponse, Category,
+    ChatMessageResponse, ChatResponse, CreateTodoRequest, DecisionStats, EmailResponse,
+    GoogleAccountResponse, LoginInitResponse, PipelineStatsResponse, ProposedCalendarEventAction,
+    ProposedTodoAction, RejectDecisionRequest, SendChatMessageRequest, SuggestedAction, Todo,
+    UpdateAboutMeRequest, UpdateTodoRequest,
 };
 use uuid::Uuid;
 use web_sys::{Element, HtmlInputElement};
@@ -37,6 +38,8 @@ pub enum View {
     Calendar,
     DecisionLog,
     Categories,
+    Pipeline,
+    AboutMe,
 }
 
 /// Sort options for the todo list
@@ -518,6 +521,16 @@ fn authenticated_app(props: &AuthenticatedAppProps) -> Html {
         Callback::from(move |_| set_view.emit(View::Calendar))
     };
 
+    let set_view_pipeline = {
+        let set_view = ctx.set_view.clone();
+        Callback::from(move |_| set_view.emit(View::Pipeline))
+    };
+
+    let set_view_about_me = {
+        let set_view = ctx.set_view.clone();
+        Callback::from(move |_| set_view.emit(View::AboutMe))
+    };
+
     let on_logout = props.on_logout.clone();
 
     html! {
@@ -573,6 +586,18 @@ fn authenticated_app(props: &AuthenticatedAppProps) -> Html {
                     >
                         {"Categories"}
                     </button>
+                    <button
+                        class={if current_view == View::Pipeline { "nav-btn active" } else { "nav-btn" }}
+                        onclick={set_view_pipeline}
+                    >
+                        {"Pipeline"}
+                    </button>
+                    <button
+                        class={if current_view == View::AboutMe { "nav-btn active" } else { "nav-btn" }}
+                        onclick={set_view_about_me}
+                    >
+                        {"About Me"}
+                    </button>
                 </nav>
             </header>
             <main>
@@ -582,6 +607,8 @@ fn authenticated_app(props: &AuthenticatedAppProps) -> Html {
                     View::Calendar => html! { <CalendarView /> },
                     View::DecisionLog => html! { <DecisionLog /> },
                     View::Categories => html! { <CategoryManager /> },
+                    View::Pipeline => html! { <PipelineView /> },
+                    View::AboutMe => html! { <AboutMeEditor /> },
                 }}
             </main>
             <ChatWidget />
@@ -1015,8 +1042,17 @@ struct DecisionDetailProps {
 #[function_component(DecisionDetailView)]
 fn decision_detail_view(props: &DecisionDetailProps) -> Html {
     let decision = &props.decision;
-    let proposed: Option<ProposedTodoAction> =
-        serde_json::from_value(decision.proposed_action.clone()).ok();
+    let proposed: Option<ProposedTodoAction> = if decision.decision_type == "create_todo" {
+        serde_json::from_value(decision.proposed_action.clone()).ok()
+    } else {
+        None
+    };
+    let proposed_event: Option<ProposedCalendarEventAction> =
+        if decision.decision_type == "create_calendar_event" {
+            serde_json::from_value(decision.proposed_action.clone()).ok()
+        } else {
+            None
+        };
 
     html! {
         <div class="decision-detail">
@@ -1038,6 +1074,37 @@ fn decision_detail_view(props: &DecisionDetailProps) -> Html {
                     {format!("Confidence: {}% ({})", (decision.confidence * 100.0) as i32, decision.confidence_level)}
                 </p>
             </div>
+
+            {if let Some(event) = proposed_event {
+                html! {
+                    <div class="detail-section">
+                        <h4>{"Proposed Calendar Event"}</h4>
+                        <p><strong>{"Summary: "}</strong>{&event.summary}</p>
+                        <p><strong>{"When: "}</strong>{format!("{} \u{2192} {}",
+                            event.start.format("%a %b %-d, %H:%M"),
+                            event.end.format("%H:%M UTC"))}</p>
+                        {if let Some(loc) = &event.location {
+                            html! { <p><strong>{"Where: "}</strong>{loc}</p> }
+                        } else {
+                            html! {}
+                        }}
+                        {if let Some(desc) = &event.description {
+                            html! { <p><strong>{"Details: "}</strong>{desc}</p> }
+                        } else {
+                            html! {}
+                        }}
+                        <p><strong>{"Calendar: "}</strong>{event.calendar_name.clone().unwrap_or_else(|| "Agent".to_string())}</p>
+                        {if let Some(link) = &event.email_link {
+                            html! { <p><a href={link.clone()} target="_blank">{"Source email"}</a></p> }
+                        } else {
+                            html! {}
+                        }}
+                        <p class="gate-note">{"Approving creates this event on your Agent calendar."}</p>
+                    </div>
+                }
+            } else {
+                html! {}
+            }}
 
             {if let Some(action) = proposed {
                 html! {
@@ -2306,6 +2373,187 @@ fn chat_widget() -> Html {
                 }
             } else {
                 html! {}
+            }}
+        </div>
+    }
+}
+
+/// Pipeline infrastructure screen: triage mode, health, and stage counts
+#[function_component(PipelineView)]
+fn pipeline_view() -> Html {
+    let stats = use_state(|| None::<PipelineStatsResponse>);
+    let error = use_state(|| None::<String>);
+
+    {
+        let stats = stats.clone();
+        let error = error.clone();
+        use_effect_with((), move |_| {
+            let stats = stats.clone();
+            let error = error.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                match Request::get("/api/pipeline/stats").send().await {
+                    Ok(resp) if resp.ok() => match resp.json::<PipelineStatsResponse>().await {
+                        Ok(data) => stats.set(Some(data)),
+                        Err(e) => error.set(Some(format!("Bad response: {e}"))),
+                    },
+                    Ok(resp) => error.set(Some(format!("API error: {}", resp.status()))),
+                    Err(e) => error.set(Some(format!("Request failed: {e}"))),
+                }
+            });
+            || ()
+        });
+    }
+
+    let stage_order = [
+        ("pending", "Pending screening"),
+        ("archive_candidate", "Awaiting archive determination"),
+        ("archived", "Archived by agent"),
+        ("event_proposed", "Calendar events proposed"),
+        ("action_queued", "Queued for action pass"),
+        ("todo_proposed", "Todos proposed"),
+        ("kept", "Kept in inbox"),
+        ("ignored", "Ignored"),
+    ];
+
+    html! {
+        <div class="pipeline-view">
+            <h2>{"Triage Pipeline"}</h2>
+            {if let Some(err) = (*error).clone() {
+                html! { <div class="error-banner">{err}</div> }
+            } else {
+                html! {}
+            }}
+            {if let Some(s) = (*stats).clone() {
+                let count_for = |key: &str| {
+                    s.stage_counts
+                        .iter()
+                        .find(|c| c.status == key)
+                        .map(|c| c.count)
+                        .unwrap_or(0)
+                };
+                html! {
+                    <>
+                        <div class={if s.mode == "agentic" { "pipeline-mode mode-agentic" } else { "pipeline-mode mode-disabled" }}>
+                            <span class="pipeline-mode-label">{"Mode: "}</span>
+                            <strong>{&s.mode}</strong>
+                            {if let Some(t) = &s.last_cycle_at {
+                                html! { <span class="pipeline-last-cycle">{format!(" — last cycle {}", t.format("%H:%M:%S UTC"))}</span> }
+                            } else {
+                                html! {}
+                            }}
+                        </div>
+                        {if let Some(e) = &s.last_cycle_error {
+                            html! { <div class="error-banner">{format!("Last cycle error ({} consecutive): {}", s.consecutive_failures, e)}</div> }
+                        } else {
+                            html! {}
+                        }}
+                        <div class="pipeline-stages">
+                            {stage_order.iter().map(|(key, label)| {
+                                html! {
+                                    <div class="pipeline-stage-card" key={*key}>
+                                        <div class="pipeline-stage-count">{count_for(key)}</div>
+                                        <div class="pipeline-stage-label">{*label}</div>
+                                    </div>
+                                }
+                            }).collect::<Html>()}
+                        </div>
+                    </>
+                }
+            } else {
+                html! { <p>{"Loading..."}</p> }
+            }}
+        </div>
+    }
+}
+
+/// Editor for the about-me document the action-stage agent reads
+#[function_component(AboutMeEditor)]
+fn about_me_editor() -> Html {
+    let content = use_state(String::new);
+    let status = use_state(|| None::<String>);
+    let loaded = use_state(|| false);
+
+    {
+        let content = content.clone();
+        let loaded = loaded.clone();
+        use_effect_with((), move |_| {
+            let content = content.clone();
+            let loaded = loaded.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                if let Ok(resp) = Request::get("/api/about-me").send().await {
+                    if resp.ok() {
+                        if let Ok(doc) = resp.json::<AboutMeResponse>().await {
+                            content.set(doc.content);
+                        }
+                    }
+                }
+                loaded.set(true);
+            });
+            || ()
+        });
+    }
+
+    let on_input = {
+        let content = content.clone();
+        Callback::from(move |e: InputEvent| {
+            let target: web_sys::HtmlTextAreaElement = e.target_unchecked_into();
+            content.set(target.value());
+        })
+    };
+
+    let on_save = {
+        let content = content.clone();
+        let status = status.clone();
+        Callback::from(move |_| {
+            let body = UpdateAboutMeRequest {
+                content: (*content).clone(),
+            };
+            let status = status.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let result = Request::put("/api/about-me")
+                    .header("Content-Type", "application/json")
+                    .json(&body)
+                    .expect("serializable body")
+                    .send()
+                    .await;
+                match result {
+                    Ok(resp) if resp.ok() => status.set(Some("Saved".to_string())),
+                    Ok(resp) => status.set(Some(format!("Save failed: {}", resp.status()))),
+                    Err(e) => status.set(Some(format!("Save failed: {e}"))),
+                }
+            });
+        })
+    };
+
+    html! {
+        <div class="about-me-editor">
+            <h2>{"About Me"}</h2>
+            <p class="about-me-hint">
+                {"The triage agent reads this before deciding what belongs on your todo \
+                  list. Describe who you are, active projects, what deserves a todo, \
+                  senders who always matter, and what is noise."}
+            </p>
+            {if *loaded {
+                html! {
+                    <>
+                        <textarea
+                            class="about-me-textarea"
+                            rows="24"
+                            value={(*content).clone()}
+                            oninput={on_input}
+                        />
+                        <div class="about-me-actions">
+                            <button class="btn-primary" onclick={on_save}>{"Save"}</button>
+                            {if let Some(msg) = (*status).clone() {
+                                html! { <span class="about-me-status">{msg}</span> }
+                            } else {
+                                html! {}
+                            }}
+                        </div>
+                    </>
+                }
+            } else {
+                html! { <p>{"Loading..."}</p> }
             }}
         </div>
     }

--- a/crates/frontend/styles.css
+++ b/crates/frontend/styles.css
@@ -1960,3 +1960,97 @@ main {
     color: #e74c3c;
     font-weight: 500;
 }
+
+/* Pipeline view */
+.pipeline-view {
+    padding: 1.5rem;
+}
+
+.pipeline-mode {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    margin-bottom: 1rem;
+}
+
+.pipeline-mode.mode-agentic {
+    background: #e6f7ed;
+    color: #1a7f37;
+}
+
+.pipeline-mode.mode-disabled {
+    background: #fff4e5;
+    color: #9a6700;
+}
+
+.pipeline-stages {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.pipeline-stage-card {
+    background: var(--card-bg, #fff);
+    border: 1px solid var(--border-color, #e1e4e8);
+    border-radius: 8px;
+    padding: 1rem;
+    text-align: center;
+}
+
+.pipeline-stage-count {
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.pipeline-stage-label {
+    color: var(--text-secondary, #57606a);
+    font-size: 0.85rem;
+    margin-top: 0.25rem;
+}
+
+.error-banner {
+    background: #ffebe9;
+    color: #cf222e;
+    border: 1px solid #ff818266;
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+}
+
+/* About-me editor */
+.about-me-editor {
+    padding: 1.5rem;
+    max-width: 800px;
+}
+
+.about-me-hint {
+    color: var(--text-secondary, #57606a);
+    margin-bottom: 1rem;
+}
+
+.about-me-textarea {
+    width: 100%;
+    font-family: inherit;
+    font-size: 0.95rem;
+    padding: 0.75rem;
+    border: 1px solid var(--border-color, #e1e4e8);
+    border-radius: 8px;
+    resize: vertical;
+}
+
+.about-me-actions {
+    margin-top: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.about-me-status {
+    color: var(--text-secondary, #57606a);
+}
+
+.gate-note {
+    font-style: italic;
+    color: var(--text-secondary, #57606a);
+}


### PR DESCRIPTION
## Summary

Final PR of the triage pipeline trilogy — the UI and the deployment pieces that flip production from keyword-fallback to agentic mode.

**Frontend**
- **Pipeline screen** (new nav tab): triage mode badge (agentic/disabled), last cycle time, error banner with consecutive-failure count, and per-stage counts (pending → screening → archived / events proposed / action queue → todos proposed / kept / ignored), from the typed `GET /api/pipeline/stats`.
- **About Me editor** (new nav tab): edit the personal-context document the Opus action pass reads. Stored in the DB only — never in this public repo.
- **Decision inbox**: `create_calendar_event` proposals now render properly (summary, time, location, target calendar, source-email link) with an explicit "approving creates this event" note.

**Deploy**
- `agent-cli` gets a proper binary name (`[[bin]]`) and ships in the image at `/usr/local/bin/agent-cli`.
- Image now includes Node 22 + `@anthropic-ai/claude-code` — the triage session runtime. Without `ANTHROPIC_API_KEY` the backend still boots into keyword-fallback mode, so this deploy is behavior-neutral until the key is injected (coordinated with infrastructure).
- `container.yml` builds/uploads both binaries.

## Deploy sequence (with infrastructure)

1. This merges → new image (bigger: +Node/claude). Watchtower deploys; boot log shows `Email triage mode: disabled (ANTHROPIC_API_KEY not set)`.
2. Infra adds `ANTHROPIC_API_KEY` from the 1Password item → restart → `Email triage mode: agentic`; the pipeline self-recovers without a rebuild.
3. The ~100-email stored corpus becomes the live benchmark against the 13/100 keyword baseline; calendar/todo proposals stay human-gated throughout.

## Testing

- `cargo test --workspace`, clippy `--all-features` zero warnings, fmt, `cargo build --release --bin agent-cli` — all clean
- Frontend compiles; visual verification after deploy