### PR TITLE
Dry-run archive mode, bulk audit endpoint, reap timed-out sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,5 @@ RUST_LOG=info
 # TRIAGE_ARCHIVE_MODEL=claude-sonnet-4-5
 # TRIAGE_ACTION_MODEL=claude-opus-4-8
 # TRIAGE_SESSION_TIMEOUT_SECS=600
+# Archive policy: "propose" (dry run, default) or "execute" (auto-archive)
+# TRIAGE_ARCHIVE_MODE=propose

--- a/crates/backend/src/db.rs
+++ b/crates/backend/src/db.rs
@@ -343,6 +343,18 @@ pub mod emails {
         Ok(())
     }
 
+    /// Load a set of emails by primary key
+    pub async fn list_by_ids(
+        conn: &mut AsyncPgConnection,
+        ids: &[Uuid],
+    ) -> anyhow::Result<Vec<Email>> {
+        use crate::schema::emails::dsl::*;
+
+        let items = emails.filter(id.eq_any(ids)).load::<Email>(conn).await?;
+
+        Ok(items)
+    }
+
     /// List emails in a given triage state, oldest first
     pub async fn list_by_triage_status(
         conn: &mut AsyncPgConnection,
@@ -568,6 +580,24 @@ pub mod decisions {
         let rows = agent_decisions
             .filter(status.eq(DecisionStatus::Proposed.as_str()))
             .order_by(created_at.desc())
+            .load::<AgentDecisionRow>(conn)
+            .await?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    /// List decisions of one type, newest first
+    pub async fn list_by_type(
+        conn: &mut AsyncPgConnection,
+        decision_type_val: &str,
+        limit: i64,
+    ) -> anyhow::Result<Vec<AgentDecision>> {
+        use crate::schema::agent_decisions::dsl::*;
+
+        let rows = agent_decisions
+            .filter(decision_type.eq(decision_type_val))
+            .order_by(created_at.desc())
+            .limit(limit)
             .load::<AgentDecisionRow>(conn)
             .await?;
 

--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -5,15 +5,15 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use shared_types::{
     AboutMeResponse, AgentDecisionResponse, AgentRuleResponse, ApproveDecisionRequest,
-    BatchApproveDecisionsRequest, BatchOperationFailure, BatchOperationResponse,
-    BatchRejectDecisionsRequest, CalendarEventQuery, CalendarEventResponse, Category,
-    ChatHistoryQuery, ChatIntent, ChatMessageResponse, ChatResponse, CreateAgentDecisionRequest,
-    CreateAgentRuleRequest, CreateCalendarEventRequest, CreateCalendarEventResponse,
-    CreateCategoryRequest, CreateTodoRequest, DecisionStats, EmailListQuery, EmailResponse,
-    GoogleAccountResponse, PipelineStatsResponse, RejectDecisionRequest, RuleListQuery,
-    SendChatMessageRequest, SuggestedAction, Todo, TriageDecideRequest, TriageDecideResponse,
-    TriageStageCount, UpdateAboutMeRequest, UpdateAgentRuleRequest, UpdateCategoryRequest,
-    UpdateTodoRequest,
+    ArchiveReviewItem, ArchiveReviewResponse, BatchApproveDecisionsRequest, BatchOperationFailure,
+    BatchOperationResponse, BatchRejectDecisionsRequest, CalendarEventQuery, CalendarEventResponse,
+    Category, ChatHistoryQuery, ChatIntent, ChatMessageResponse, ChatResponse,
+    CreateAgentDecisionRequest, CreateAgentRuleRequest, CreateCalendarEventRequest,
+    CreateCalendarEventResponse, CreateCategoryRequest, CreateTodoRequest, DecisionStats,
+    EmailListQuery, EmailResponse, GoogleAccountResponse, PipelineStatsResponse,
+    RejectDecisionRequest, RuleListQuery, SendChatMessageRequest, SuggestedAction, Todo,
+    TriageDecideRequest, TriageDecideResponse, TriageStageCount, UpdateAboutMeRequest,
+    UpdateAgentRuleRequest, UpdateCategoryRequest, UpdateTodoRequest,
 };
 use uuid::Uuid;
 
@@ -307,6 +307,51 @@ pub async fn get_pipeline_stats(
     }))
 }
 
+// Bulk audit surface for archive determinations (the dry-run review)
+pub async fn get_archive_review(
+    State(state): State<AppState>,
+) -> ApiResult<Json<ArchiveReviewResponse>> {
+    let mut conn = get_conn(&state.pool).await?;
+
+    let decisions_list = decisions::list_by_type(&mut conn, "archive", 500).await?;
+    let email_ids: Vec<Uuid> = decisions_list.iter().filter_map(|d| d.source_id).collect();
+    let emails_list = emails::list_by_ids(&mut conn, &email_ids).await?;
+    let accounts = google_accounts::list_all(&mut conn).await?;
+
+    let items = decisions_list
+        .into_iter()
+        .filter_map(|d| {
+            let email = d
+                .source_id
+                .and_then(|sid| emails_list.iter().find(|e| e.id == sid))?;
+            let account_email = accounts
+                .iter()
+                .find(|a| a.id == email.account_id)
+                .map(|a| a.email.clone())
+                .unwrap_or_default();
+            Some(ArchiveReviewItem {
+                decision_id: d.id,
+                email_id: email.id,
+                status: d.status.clone(),
+                confidence: d.confidence,
+                reasoning: d.reasoning.clone(),
+                decided_at: d.created_at,
+                account_email,
+                subject: email.subject.clone(),
+                from_address: email.from_address.clone(),
+                from_name: email.from_name.clone(),
+                received_at: email.received_at,
+                snippet: email.snippet.clone(),
+            })
+        })
+        .collect();
+
+    Ok(Json(ArchiveReviewResponse {
+        archive_mode: crate::services::triage::archive_mode(),
+        items,
+    }))
+}
+
 // ============================================================================
 // Agent Decision handlers
 // ============================================================================
@@ -380,20 +425,41 @@ pub async fn approve_decision(
 ) -> ApiResult<Json<AgentDecisionResponse>> {
     let mut conn = state.pool.get().await?;
     let result = DecisionService::approve(&mut conn, id, payload.modifications).await?;
-    let is_calendar = result.decision.decision_type == "create_calendar_event";
+    let decision_type = result.decision.decision_type.clone();
     drop(conn);
 
-    // Approving a gated calendar proposal executes the write
-    if is_calendar {
-        crate::services::TriageService::execute_calendar_decision(&state.pool, id)
-            .await
-            .map_err(ApiError::Internal)?;
+    // Approving a gated proposal executes its side effect
+    if execute_approved_side_effect(&state, id, &decision_type).await? {
         let mut conn = state.pool.get().await?;
         let refreshed = decisions::get_by_id(&mut conn, id).await?;
         return Ok(Json(refreshed.into()));
     }
 
     Ok(Json(result.decision.into()))
+}
+
+/// Run the external side effect for an approved decision, if it has one.
+/// Returns true when something executed (caller should re-read the decision).
+async fn execute_approved_side_effect(
+    state: &AppState,
+    decision_id: Uuid,
+    decision_type: &str,
+) -> Result<bool, ApiError> {
+    match decision_type {
+        "create_calendar_event" => {
+            crate::services::TriageService::execute_calendar_decision(&state.pool, decision_id)
+                .await
+                .map_err(ApiError::Internal)?;
+            Ok(true)
+        }
+        "archive" => {
+            crate::services::TriageService::execute_archive_decision(&state.pool, decision_id)
+                .await
+                .map_err(ApiError::Internal)?;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
 }
 
 pub async fn reject_decision(
@@ -417,7 +483,7 @@ pub async fn batch_approve_decisions(
     Json(payload): Json<BatchApproveDecisionsRequest>,
 ) -> ApiResult<Json<BatchOperationResponse>> {
     let result = DecisionService::batch_approve(&state.pool, payload.decision_ids).await?;
-    let failed = result
+    let mut failed: Vec<BatchOperationFailure> = result
         .failed
         .into_iter()
         .map(|f| BatchOperationFailure {
@@ -425,10 +491,25 @@ pub async fn batch_approve_decisions(
             error: f.error,
         })
         .collect();
-    Ok(Json(BatchOperationResponse {
-        successful: result.successful,
-        failed,
-    }))
+
+    // Execute side effects (archives, calendar writes) per approved decision;
+    // an execution failure downgrades that id to failed rather than aborting
+    let mut successful = Vec::with_capacity(result.successful.len());
+    for id in result.successful {
+        let decision_type = {
+            let mut conn = state.pool.get().await?;
+            decisions::get_by_id(&mut conn, id).await?.decision_type
+        };
+        match execute_approved_side_effect(&state, id, &decision_type).await {
+            Ok(_) => successful.push(id),
+            Err(e) => failed.push(BatchOperationFailure {
+                id,
+                error: format!("approved but execution failed: {e:?}"),
+            }),
+        }
+    }
+
+    Ok(Json(BatchOperationResponse { successful, failed }))
 }
 
 pub async fn batch_reject_decisions(

--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -133,6 +133,10 @@ async fn main() -> anyhow::Result<()> {
         // Triage pipeline routes (agent-cli + pipeline screen)
         .route("/triage/decisions", post(handlers::post_triage_decision))
         .route("/pipeline/stats", get(handlers::get_pipeline_stats))
+        .route(
+            "/pipeline/archive-review",
+            get(handlers::get_archive_review),
+        )
         // Chat routes
         .route("/chat", post(handlers::send_chat_message))
         .route("/chat/history", get(handlers::get_chat_history))

--- a/crates/backend/src/pollers/triage.rs
+++ b/crates/backend/src/pollers/triage.rs
@@ -165,6 +165,15 @@ pub async fn start_triage_task(pool: DbPool, auth_config: Arc<AuthConfig>, healt
                 config.archive_model,
                 config.action_model
             );
+            tracing::info!(
+                "Triage archive mode: {} ({})",
+                crate::services::triage::archive_mode(),
+                if crate::services::triage::archive_mode() == "execute" {
+                    "auto-archives on determination"
+                } else {
+                    "dry run - determinations recorded as proposals only"
+                }
+            );
             health.write().await.mode = "agentic".to_string();
         }
         Err(reason) => {
@@ -370,10 +379,25 @@ async fn run_stage(
         emails.len()
     );
 
-    let outputs = tokio::time::timeout(timeout, client.query(&prompt))
-        .await
-        .context("Agent session timed out")?
-        .context("Agent session failed")?;
+    let result = tokio::time::timeout(timeout, client.query(&prompt)).await;
+
+    // Always reap the claude subprocess — the crate does not kill on drop, so
+    // skipping shutdown on the error paths would orphan a session that keeps
+    // burning memory and tokens
+    let outputs = match result {
+        Ok(Ok(outputs)) => {
+            client.shutdown().await.ok();
+            outputs
+        }
+        Ok(Err(e)) => {
+            client.shutdown().await.ok();
+            return Err(e).context("Agent session failed");
+        }
+        Err(_) => {
+            client.shutdown().await.ok();
+            anyhow::bail!("Agent session timed out after {timeout:?}; claude process killed");
+        }
+    };
 
     for output in &outputs {
         if let claude_codes::ClaudeOutput::Result(r) = output {
@@ -388,6 +412,5 @@ async fn run_stage(
         }
     }
 
-    client.shutdown().await.ok();
     Ok(())
 }

--- a/crates/backend/src/services/triage.rs
+++ b/crates/backend/src/services/triage.rs
@@ -21,6 +21,16 @@ pub const AGENT_ARCHIVE_LABEL: &str = "agent-archived";
 /// Default calendar for agent-created events
 pub const AGENT_CALENDAR_NAME: &str = "Agent";
 
+/// Archive execution policy. "propose" (the default) records Sonnet's
+/// determinations as gated proposals with full fidelity but never touches
+/// Gmail — the dry-run mode. "execute" auto-archives on determination.
+pub fn archive_mode() -> String {
+    match std::env::var("TRIAGE_ARCHIVE_MODE").as_deref() {
+        Ok("execute") => "execute".to_string(),
+        _ => "propose".to_string(),
+    }
+}
+
 /// Permalink to a message in the account's Gmail UI
 pub fn gmail_permalink(account_email: &str, gmail_id: &str) -> String {
     format!("https://mail.google.com/mail/u/{account_email}/#all/{gmail_id}")
@@ -101,6 +111,34 @@ impl TriageService {
             }
 
             TriageDecideAction::Archive => {
+                // Dry-run mode: identical determination, recorded as a gated
+                // proposal; approval executes. Same prompts, same model, same
+                // wire path — only this final side effect differs.
+                if archive_mode() != "execute" {
+                    let decision_id = db::decisions::create_with_status(
+                        &mut conn,
+                        "email",
+                        Some(email.id),
+                        Some(&email.gmail_id),
+                        DecisionType::Archive.as_str(),
+                        "{}",
+                        &req.reasoning,
+                        reasoning_details.as_deref(),
+                        0.9,
+                        DecisionStatus::Proposed.as_str(),
+                        None,
+                    )
+                    .await?;
+                    db::emails::set_triage_status(&mut conn, email.id, "archive_proposed").await?;
+                    db::emails::mark_processed(&mut conn, email.id).await?;
+                    return Ok(TriageDecideResponse {
+                        email_id: email.id,
+                        decision_id: Some(decision_id),
+                        triage_status: "archive_proposed".to_string(),
+                        executed: false,
+                    });
+                }
+
                 let account = db::google_accounts::get_by_id(&mut conn, email.account_id)
                     .await
                     .context("Account for email not found")?;
@@ -235,6 +273,35 @@ impl TriageService {
         }
     }
 
+    /// Execute an approved archive decision: label + archive in Gmail and
+    /// bring the email's pipeline state up to date
+    pub async fn execute_archive_decision(pool: &DbPool, decision_id: Uuid) -> Result<()> {
+        let mut conn = pool.get().await.context("Failed to get DB connection")?;
+
+        let decision = db::decisions::get_by_id(&mut conn, decision_id)
+            .await
+            .context("Decision not found")?;
+        let email_id = decision
+            .source_id
+            .context("Archive decision has no source email")?;
+        let email = db::emails::get_by_id(&mut conn, email_id).await?;
+        let account = db::google_accounts::get_by_id(&mut conn, email.account_id).await?;
+        drop(conn);
+
+        let client = GmailClient::from_account(&account).await?;
+        let label_id = client.ensure_label(AGENT_ARCHIVE_LABEL).await?;
+        client
+            .archive_with_label(&email.gmail_id, &label_id)
+            .await?;
+
+        let mut conn = pool.get().await.context("Failed to get DB connection")?;
+        db::emails::mark_archived_in_gmail(&mut conn, email.id).await?;
+        db::emails::set_triage_status(&mut conn, email.id, "archived").await?;
+        db::decisions::mark_executed(&mut conn, decision_id).await?;
+
+        Ok(())
+    }
+
     /// Execute an approved calendar-event decision (the gated half of the
     /// event flow). Returns the created event's ID.
     pub async fn execute_calendar_decision(pool: &DbPool, decision_id: Uuid) -> Result<String> {
@@ -286,6 +353,14 @@ impl TriageService {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn archive_mode_defaults_to_propose() {
+        // Absent or unrecognized values must fall back to the safe dry-run
+        // mode; only the literal "execute" enables Gmail mutation
+        std::env::remove_var("TRIAGE_ARCHIVE_MODE");
+        assert_eq!(archive_mode(), "propose");
+    }
 
     #[test]
     fn permalink_targets_the_account_mailbox() {

--- a/crates/shared-types/src/lib.rs
+++ b/crates/shared-types/src/lib.rs
@@ -402,6 +402,30 @@ pub struct TriageStageCount {
     pub count: i64,
 }
 
+/// One archive determination with its email context, for bulk audit
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArchiveReviewItem {
+    pub decision_id: Uuid,
+    pub email_id: Uuid,
+    pub status: String,
+    pub confidence: f32,
+    pub reasoning: String,
+    pub decided_at: DateTime<Utc>,
+    pub account_email: String,
+    pub subject: String,
+    pub from_address: String,
+    pub from_name: Option<String>,
+    pub received_at: DateTime<Utc>,
+    pub snippet: Option<String>,
+}
+
+/// Bulk view of archive determinations (dry-run audit surface)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArchiveReviewResponse {
+    pub archive_mode: String,
+    pub items: Vec<ArchiveReviewItem>,
+}
+
 /// Typed pipeline/triage health status (stable shape; consumed by monitoring)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PipelineStatsResponse {


### PR DESCRIPTION
## Summary

Blocking changes for first agentic activation, per Matt's dry-run requirement (relayed by infrastructure).

**`TRIAGE_ARCHIVE_MODE=propose|execute` — default `propose` (dry run).** In propose mode, Sonnet's archive determinations run with full fidelity — same prompts, same model, same `agent-cli` → REST path, same decision rows and reasoning — but land as `proposed` decisions and **nothing touches Gmail**. This is a policy branch at the final side-effect only, not a separate code path, so the dry run exercises exactly what production would do. Only the literal value `execute` enables auto-archive; absent or unrecognized values fall back to propose (tested). Boot log states the mode explicitly.

**Approval executes.** Approving an `archive` decision (singly or via the existing batch-approve) now performs the Gmail label+archive; `create_calendar_event` execution generalized into the same side-effect dispatcher. Batch approvals that fail execution are downgraded to per-id failures rather than aborting the batch. So the dry-run audit has a real payoff: approve the good calls in bulk and they execute.

**`GET /api/pipeline/archive-review`** — the bulk audit surface: typed `ArchiveReviewResponse { archive_mode, items[] }`, each item carrying decision id/status/confidence/reasoning plus the email's subject/from/received/snippet/account. One payload, up to 500 newest determinations. The decision inbox's existing multi-select batch approve completes the loop in the UI.

**Session reaping fix.** `claude-codes` does not kill the child on drop; our timeout and error paths previously orphaned the claude subprocess — exactly the failure infra's OOM question probed. All exits from `run_stage` now shut the child down explicitly.

## Testing
- `cargo test --workspace` (new: archive-mode default safety), clippy `--all-features` zero warnings, fmt clean