### PR TITLE
Log triage session start for unambiguous stage attribution

### DIFF
--- a/crates/backend/src/pollers/triage.rs
+++ b/crates/backend/src/pollers/triage.rs
@@ -385,6 +385,14 @@ async fn run_stage(
     timeout: Duration,
     credential: &TriageCredential,
 ) -> Result<()> {
+    // Explicit stage-start marker so a session's run window is observed, not
+    // inferred from the previous stage's completion — makes memory/profile
+    // attribution unambiguous even for the first stage of a cycle.
+    tracing::info!(
+        "Triage session starting: model={model} emails={}",
+        emails.len()
+    );
+
     let workdir = tempfile::tempdir().context("Failed to create session workdir")?;
 
     std::fs::write(


### PR DESCRIPTION
## Summary

One-line observability improvement requested during the first-run memory profiling. `run_stage` already logs a completion line per stage (`Triage session complete: model=… …`), but with no start line, a stage's run window has to be *inferred* as (previous completion → this completion) — which means the **first** stage of every cycle has no observed start, permanently, on every profile anyone takes.

Adds an explicit `Triage session starting: model=… emails=…` at the top of `run_stage`, so each session's window is bracketed by observed start+complete lines. `docker logs --timestamps` (UTC) then aligns directly against container-memory samples for exact stage attribution of a memory peak.

No behavior change; logging only.

## Testing
- `cargo clippy --all-features` with `-Dwarnings`, `cargo build --locked` — clean