### PR TITLE
Dismiss account popover on outside click

### DIFF
--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -201,6 +201,11 @@ fn account_status() -> Html {
         Callback::from(move |_| expanded.set(!*expanded))
     };
 
+    let collapse = {
+        let expanded = expanded.clone();
+        Callback::from(move |_| expanded.set(false))
+    };
+
     let total_accounts = accounts.len();
     let error_count = accounts
         .iter()
@@ -222,6 +227,10 @@ fn account_status() -> Html {
             {if *expanded {
                 let account_list = (*accounts).clone();
                 html! {
+                    <>
+                    // Invisible full-screen layer under the dropdown: a click
+                    // anywhere outside it dismisses the popover
+                    <div class="popover-backdrop" onclick={collapse}></div>
                     <div class="account-status-dropdown">
                         <div class="account-section">
                             <div class="account-section-header">
@@ -275,6 +284,7 @@ fn account_status() -> Html {
                             }}
                         </div>
                     </div>
+                    </>
                 }
             } else {
                 html! {}

--- a/crates/frontend/styles.css
+++ b/crates/frontend/styles.css
@@ -2090,3 +2090,12 @@ main {
 .claude-auth-flow a {
     word-break: break-all;
 }
+
+/* Click-away layer for popovers: sits under the dropdown (z-index 100),
+   over everything else, and dismisses on any click */
+.popover-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 99;
+    background: transparent;
+}


### PR DESCRIPTION
## Summary

The @ account-status popover previously only closed by clicking the @ button again. Now, while it's open, a transparent full-viewport backdrop renders underneath it (z-index 99, below the dropdown's 100), so a click anywhere else in the app dismisses it. Clicks inside the dropdown still work normally; the @ button itself also still closes it (the backdrop covers it while open).

No behavior change to the popover contents or account-health display.

## Testing
- `cargo check -p frontend` with `-Dwarnings`, `trunk build` — clean
- Pattern is CSS + one callback; no new dependencies