### PR TITLE
Fix Claude login hang: outcome-driven completion, retryable rejection, flow TTL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -428,7 +428,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "claude-codes"
 version = "2.1.220"
-source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=984ea30538d4fb80a07812a522217877dfb1e00b#984ea30538d4fb80a07812a522217877dfb1e00b"
+source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=3fe682e66d73df52f4e4cc5a256b10c3031e2290#3fe682e66d73df52f4e4cc5a256b10c3031e2290"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1918,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1989,9 +1989,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -2492,10 +2492,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pq-sys"
-version = "0.4.8"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0052426df997c0cbd30789eb44ca097e3541717a7b8fa36b1c464ee7edebd"
+checksum = "574ddd6a267294433f140b02a726b0640c43cf7c6f717084684aaa3b285aba61"
 dependencies = [
+ "libc",
+ "pkg-config",
  "vcpkg",
 ]
 

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -47,7 +47,7 @@ async-trait = "0.1.89"
 jsonwebtoken = "9"
 cookie = "0.18"
 google-calendar3 = "6.0.0"
-claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "984ea30538d4fb80a07812a522217877dfb1e00b", features = ["auth"] }
+claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "3fe682e66d73df52f4e4cc5a256b10c3031e2290", features = ["auth"] }
 tempfile = "3.27.0"
 
 # Pre-compressed static frontend assets (brotli/gzip, ETag/304, SPA fallback).

--- a/crates/backend/src/error.rs
+++ b/crates/backend/src/error.rs
@@ -43,6 +43,10 @@ pub enum ApiError {
     #[error("Invalid request: {0}")]
     BadRequest(String),
 
+    /// Resource existed but is no longer available (e.g. an expired flow)
+    #[error("{0}")]
+    Gone(String),
+
     /// JSON parsing error
     #[error("Invalid JSON: {0}")]
     JsonParse(#[from] serde_json::Error),
@@ -123,6 +127,7 @@ impl IntoResponse for ApiError {
                 None,
             ),
             ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone(), None),
+            ApiError::Gone(msg) => (StatusCode::GONE, msg.clone(), None),
             ApiError::JsonParse(e) => {
                 tracing::warn!("JSON parse error: {:?}", e);
                 (

--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -312,10 +312,16 @@ pub async fn get_pipeline_stats(
 // Claude Code login flow (mints the pipeline's subscription credential)
 // ============================================================================
 
+/// Abandoned login flows are reaped after this long (see the reaper task in
+/// main.rs); complete also refuses flows older than this
+pub const LOGIN_FLOW_TTL: std::time::Duration = std::time::Duration::from_secs(600);
+
 pub async fn claude_auth_start(
     State(state): State<AppState>,
 ) -> ApiResult<Json<ClaudeAuthStartResponse>> {
     use claude_codes::auth::{LoginFlow, LoginMode};
+
+    tracing::info!("Claude login: starting setup-token flow");
 
     // PTY interaction is blocking; drive it off the async runtime
     let (flow, auth_url) = tokio::task::spawn_blocking(|| {
@@ -328,14 +334,18 @@ pub async fn claude_auth_start(
     })
     .await
     .map_err(|e| ApiError::Internal(anyhow::anyhow!("Login task panicked: {e}")))?
-    .map_err(ApiError::Internal)?;
+    .map_err(|e| {
+        tracing::error!("Claude login: start failed: {e:#}");
+        ApiError::Internal(e)
+    })?;
 
     // Replacing any previous in-flight flow cancels it (Drop kills the child)
     *state
         .claude_login
         .lock()
-        .expect("claude_login mutex poisoned") = Some(flow);
+        .expect("claude_login mutex poisoned") = Some((flow, std::time::Instant::now()));
 
+    tracing::info!("Claude login: auth URL extracted, awaiting code paste");
     Ok(Json(ClaudeAuthStartResponse { auth_url }))
 }
 
@@ -343,26 +353,61 @@ pub async fn claude_auth_complete(
     State(state): State<AppState>,
     Json(req): Json<ClaudeAuthCompleteRequest>,
 ) -> ApiResult<Json<ClaudeAuthStatusResponse>> {
-    let flow = state
+    let (flow, started) = state
         .claude_login
         .lock()
         .expect("claude_login mutex poisoned")
         .take()
         .ok_or_else(|| {
-            ApiError::BadRequest("No Claude login in progress - start one first".to_string())
+            ApiError::Gone("No Claude login in progress - start one first".to_string())
         })?;
 
+    if started.elapsed() > LOGIN_FLOW_TTL {
+        // Dropping the flow kills the PTY child
+        tracing::info!("Claude login: flow expired before code arrived");
+        return Err(ApiError::Gone(
+            "Login expired - start a new one".to_string(),
+        ));
+    }
+
     let code = req.code.trim().to_string();
-    let outcome = tokio::task::spawn_blocking(move || {
+    tracing::info!("Claude login: code received, submitting to CLI");
+
+    // Outcome-driven wait: returns on minted token or CLI OAuth error, not on
+    // process exit (the CLI never exits on a rejected code)
+    let result = tokio::task::spawn_blocking(move || {
         let mut flow = flow;
-        flow.submit_code(&code)
-            .map_err(|e| anyhow::anyhow!("Submitting code failed: {e}"))?;
-        flow.finish(std::time::Duration::from_secs(60))
-            .map_err(|e| anyhow::anyhow!("Login did not complete: {e}"))
+        let outcome = flow.submit_code_and_wait(&code, std::time::Duration::from_secs(30));
+        (flow, outcome)
     })
     .await
-    .map_err(|e| ApiError::Internal(anyhow::anyhow!("Login task panicked: {e}")))?
-    .map_err(ApiError::Internal)?;
+    .map_err(|e| ApiError::Internal(anyhow::anyhow!("Login task panicked: {e}")))?;
+
+    let (flow, outcome) = result;
+    let outcome = match outcome {
+        Ok(outcome) => outcome,
+        Err(claude_codes::Error::CodeRejected { message }) => {
+            // The CLI is alive awaiting a retry against the same PKCE
+            // verifier; put the flow back so a corrected paste reaches it
+            tracing::warn!("Claude login: code rejected by CLI: {message}");
+            *state
+                .claude_login
+                .lock()
+                .expect("claude_login mutex poisoned") = Some((flow, started));
+            return Err(ApiError::BadRequest(format!(
+                "Code rejected: {message} - check the paste and try again"
+            )));
+        }
+        Err(e) => {
+            // Fatal: dropping the flow kills the child; UI restarts the flow
+            tracing::error!("Claude login: failed: {e}");
+            drop(flow);
+            return Err(ApiError::Internal(anyhow::anyhow!(
+                "Login did not complete: {e}"
+            )));
+        }
+    };
+    drop(flow); // success: reap the CLI child
 
     let token = outcome.token.ok_or_else(|| {
         let tail: String = outcome
@@ -383,7 +428,7 @@ pub async fn claude_auth_complete(
     crate::db::claude_credentials::upsert(&mut conn, &token).await?;
     let cred = crate::db::claude_credentials::get(&mut conn).await?;
 
-    tracing::info!("Claude Code credential stored via in-app login");
+    tracing::info!("Claude login: credential minted and stored");
 
     Ok(Json(ClaudeAuthStatusResponse {
         connected: true,

--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -44,9 +44,12 @@ pub struct AppState {
     pub pool: db::DbPool,
     pub auth_config: Arc<AuthConfig>,
     pub triage_health: pollers::TriageHealth,
-    /// In-flight interactive Claude Code login, if any (single-user app:
-    /// one flow at a time; replacing a flow cancels the previous one)
-    pub claude_login: Arc<std::sync::Mutex<Option<claude_codes::auth::LoginFlow>>>,
+    /// In-flight interactive Claude Code login with its start time, if any
+    /// (single-user app: one flow at a time; replacing a flow cancels the
+    /// previous one, and a reaper expires abandoned flows after a TTL so a
+    /// forgotten login can't leave a PTY child alive indefinitely)
+    pub claude_login:
+        Arc<std::sync::Mutex<Option<(claude_codes::auth::LoginFlow, std::time::Instant)>>>,
 }
 
 /// Build the full application router from shared state.
@@ -248,6 +251,31 @@ async fn main() -> anyhow::Result<()> {
         triage_health: triage_health.clone(),
         claude_login: Arc::new(std::sync::Mutex::new(None)),
     };
+
+    // Reap abandoned Claude login flows so a forgotten PTY child can't
+    // linger inside the container's memory budget (runs in dev mode too:
+    // the login flow exists regardless of the pollers)
+    let login_reaper_state = app_state.claude_login.clone();
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            tick.tick().await;
+            let expired = {
+                let mut slot = login_reaper_state
+                    .lock()
+                    .expect("claude_login mutex poisoned");
+                match slot.as_ref() {
+                    Some((_, started)) if started.elapsed() > handlers::LOGIN_FLOW_TTL => {
+                        slot.take()
+                    }
+                    _ => None,
+                }
+            };
+            if expired.is_some() {
+                tracing::info!("Reaped abandoned Claude login flow (TTL exceeded)");
+            }
+        }
+    });
 
     if !args.dev_mode {
         // Start email polling background task (ingestion is never gated on triage)

--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -2484,11 +2484,27 @@ fn claude_auth_card() -> Html {
                         code.set(String::new());
                         refresh.emit(());
                     }
-                    Ok(resp) => {
+                    Ok(resp) if resp.status() == 400 => {
+                        // Code rejected: the same login session is still alive
+                        // awaiting a corrected paste, so keep the URL + input
                         let text = resp.text().await.unwrap_or_default();
-                        error.set(Some(format!("Login failed ({}): {}", resp.status(), text)));
+                        error.set(Some(text));
                     }
-                    Err(e) => error.set(Some(format!("Login failed: {e}"))),
+                    Ok(resp) => {
+                        // Fatal (expired flow, CLI failure): reset to step one
+                        let text = resp.text().await.unwrap_or_default();
+                        auth_url.set(None);
+                        code.set(String::new());
+                        error.set(Some(format!(
+                            "Login failed ({}): {} - click Login to start over",
+                            resp.status(),
+                            text
+                        )));
+                    }
+                    Err(e) => {
+                        auth_url.set(None);
+                        error.set(Some(format!("Login failed: {e}")));
+                    }
                 }
                 busy.set(false);
             });


### PR DESCRIPTION
## Summary

Fixes the production login hang (51s spinner → client abort, no token stored). Root causes, diagnosed by infrastructure against the live container: the `claude setup-token` CLI **never exits on a rejected code** (it prints `OAuth error … Press Enter to retry` and waits), and its TUI renders text with cursor-column escapes so phrase matching can never fire. The old flow waited on process exit — a wait that could not end.

**Crate side** (pin bumped to `rust-code-agent-sdks` rev `3fe682e`, [PR #258](https://github.com/meawoppl/rust-code-agent-sdks/pull/258)): new `submit_code_and_wait` watches *output*, not exit — token found ⇒ success immediately; `OAuth error` after the current submission ⇒ typed `CodeRejected` with the CLI's own message, **leaving the flow alive** so a corrected paste reaches the same PKCE session; 1000-column PTY plus a loud display-wrap detector prevent silent token truncation/corruption.

**App side:**
- `complete` maps outcomes: rejected code → **400** with the CLI message, flow restored to AppState (paste again, same session); expired/no flow → **410 Gone**; CLI failure → 500 with transcript tail. The frontend keeps the paste field on 400 and resets to the Login button on anything else — no more silent dead sessions.
- **Flow TTL (10 min) + reaper task** (runs in dev mode too): an abandoned login no longer leaves a PTY child alive indefinitely inside the container's memory cap — same leak class as #96, closed at the other door. A repeat Login click still replaces (and kills) any prior flow, so stored flows cap at one.
- **Logging on every step** (flow started, URL extracted, code submitted, outcome) — the original incident produced zero log lines, which is why it took an hour to diagnose instead of two minutes.

## Testing
- Crate: 3 regression tests built from the captured production PTY bytes (199 pass)
- App: full workspace suite, clippy `-Dwarnings`, `--locked` build, migration-name check — clean
- Live paste-back verified in prod after deploy (requires a real browser code)