### PR TITLE
Login hardening: input sanitize, channel-diagnosed timeouts, cli-persisted success

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,9 +428,10 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "claude-codes"
 version = "2.1.220"
-source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=3fe682e66d73df52f4e4cc5a256b10c3031e2290#3fe682e66d73df52f4e4cc5a256b10c3031e2290"
+source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=828e520572e67ad72f070c1ed657f7ca64e76d4d#828e520572e67ad72f070c1ed657f7ca64e76d4d"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
  "log",
  "portable-pty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "claude-codes"
 version = "2.1.220"
-source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=828e520572e67ad72f070c1ed657f7ca64e76d4d#828e520572e67ad72f070c1ed657f7ca64e76d4d"
+source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=2aff1decc34472741f6ae3e3d1c2ce7350be3544#2aff1decc34472741f6ae3e3d1c2ce7350be3544"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "claude-codes"
 version = "2.1.220"
-source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=2aff1decc34472741f6ae3e3d1c2ce7350be3544#2aff1decc34472741f6ae3e3d1c2ce7350be3544"
+source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=5f8d34dcc51ac82bd8ec76ddc741c6ee18d1f3da#5f8d34dcc51ac82bd8ec76ddc741c6ee18d1f3da"
 dependencies = [
  "anyhow",
  "base64",

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -47,7 +47,7 @@ async-trait = "0.1.89"
 jsonwebtoken = "9"
 cookie = "0.18"
 google-calendar3 = "6.0.0"
-claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "828e520572e67ad72f070c1ed657f7ca64e76d4d", features = ["auth"] }
+claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "2aff1decc34472741f6ae3e3d1c2ce7350be3544", features = ["auth"] }
 tempfile = "3.27.0"
 
 # Pre-compressed static frontend assets (brotli/gzip, ETag/304, SPA fallback).

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -47,7 +47,7 @@ async-trait = "0.1.89"
 jsonwebtoken = "9"
 cookie = "0.18"
 google-calendar3 = "6.0.0"
-claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "2aff1decc34472741f6ae3e3d1c2ce7350be3544", features = ["auth"] }
+claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "5f8d34dcc51ac82bd8ec76ddc741c6ee18d1f3da", features = ["auth"] }
 tempfile = "3.27.0"
 
 # Pre-compressed static frontend assets (brotli/gzip, ETag/304, SPA fallback).

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -47,7 +47,7 @@ async-trait = "0.1.89"
 jsonwebtoken = "9"
 cookie = "0.18"
 google-calendar3 = "6.0.0"
-claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "3fe682e66d73df52f4e4cc5a256b10c3031e2290", features = ["auth"] }
+claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "828e520572e67ad72f070c1ed657f7ca64e76d4d", features = ["auth"] }
 tempfile = "3.27.0"
 
 # Pre-compressed static frontend assets (brotli/gzip, ETag/304, SPA fallback).

--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -446,6 +446,13 @@ pub async fn claude_auth_complete(
     };
     drop(flow); // success: reap the CLI child
 
+    tracing::info!(
+        "Claude login: outcome channels: token_source={:?} osc52={:?} copy_nudge_sent={}",
+        outcome.token_source,
+        outcome.osc52,
+        outcome.copy_nudge_sent
+    );
+
     let token = match (outcome.token, outcome.credentials_updated) {
         (Some(token), _) => token,
         (None, true) => {
@@ -457,7 +464,8 @@ pub async fn claude_auth_complete(
             // requires re-login.
             tracing::warn!(
                 "Claude login: succeeded via CLI-persisted credentials (token not \
-                 capturable); re-login will be needed after container redeploys"
+                 capturable; osc52={:?}); re-login will be needed after container redeploys",
+                outcome.osc52
             );
             String::new()
         }

--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -370,14 +370,40 @@ pub async fn claude_auth_complete(
         ));
     }
 
-    let code = req.code.trim().to_string();
-    tracing::info!("Claude login: code received, submitting to CLI");
+    // Browser copies inject invisible unicode that trim() does not touch;
+    // an empty or poisoned code presses Enter on a bad field and presents as
+    // a silent timeout. Sanitize before spending a flow attempt.
+    let code: String = req
+        .code
+        .chars()
+        .filter(|c| {
+            !c.is_whitespace()
+                && !matches!(
+                    c,
+                    '\u{200B}' | '\u{200C}' | '\u{200D}' | '\u{FEFF}' | '\u{00A0}'
+                )
+        })
+        .collect();
+    if code.is_empty() {
+        // Flow stays stored: nothing was submitted, so the session is intact
+        *state
+            .claude_login
+            .lock()
+            .expect("claude_login mutex poisoned") = Some((flow, started));
+        return Err(ApiError::BadRequest(
+            "Pasted code is empty after removing whitespace - copy it again".to_string(),
+        ));
+    }
+    tracing::info!(
+        "Claude login: code received (len={}), submitting to CLI",
+        code.len()
+    );
 
     // Outcome-driven wait: returns on minted token or CLI OAuth error, not on
     // process exit (the CLI never exits on a rejected code)
     let result = tokio::task::spawn_blocking(move || {
         let mut flow = flow;
-        let outcome = flow.submit_code_and_wait(&code, std::time::Duration::from_secs(30));
+        let outcome = flow.submit_code_and_wait(&code, std::time::Duration::from_secs(90));
         (flow, outcome)
     })
     .await
@@ -398,6 +424,17 @@ pub async fn claude_auth_complete(
                 "Code rejected: {message} - check the paste and try again"
             )));
         }
+        Err(claude_codes::Error::LoginTimeout { transcript }) => {
+            // The transcript leads with the channel diagnostics line
+            // ([channels: screen=... osc52=... credentials=...]), which names
+            // the stalled leg instead of leaving a silent mystery
+            tracing::error!("Claude login: timed out; transcript: {transcript}");
+            drop(flow);
+            let tail: String = transcript.chars().take(400).collect();
+            return Err(ApiError::Internal(anyhow::anyhow!(
+                "Login timed out. CLI state: {tail}"
+            )));
+        }
         Err(e) => {
             // Fatal: dropping the flow kills the child; UI restarts the flow
             tracing::error!("Claude login: failed: {e}");
@@ -409,20 +446,36 @@ pub async fn claude_auth_complete(
     };
     drop(flow); // success: reap the CLI child
 
-    let token = outcome.token.ok_or_else(|| {
-        let tail: String = outcome
-            .transcript
-            .chars()
-            .rev()
-            .take(300)
-            .collect::<String>()
-            .chars()
-            .rev()
-            .collect();
-        ApiError::Internal(anyhow::anyhow!(
-            "Login finished without minting a token. CLI output ended with: {tail}"
-        ))
-    })?;
+    let token = match (outcome.token, outcome.credentials_updated) {
+        (Some(token), _) => token,
+        (None, true) => {
+            // Legitimate success: the CLI accepted the code and persisted its
+            // own credentials, but never exposed the token over the PTY.
+            // Store the cli-persisted sentinel (empty token): the pipeline
+            // then relies on the CLI's disk credentials instead of an env
+            // token. Those live only inside the container, so a redeploy
+            // requires re-login.
+            tracing::warn!(
+                "Claude login: succeeded via CLI-persisted credentials (token not \
+                 capturable); re-login will be needed after container redeploys"
+            );
+            String::new()
+        }
+        (None, false) => {
+            let tail: String = outcome
+                .transcript
+                .chars()
+                .rev()
+                .take(300)
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect();
+            return Err(ApiError::Internal(anyhow::anyhow!(
+                "Login finished without minting a token. CLI output ended with: {tail}"
+            )));
+        }
+    };
 
     let mut conn = get_conn(&state.pool).await?;
     crate::db::claude_credentials::upsert(&mut conn, &token).await?;

--- a/crates/backend/src/pollers/triage.rs
+++ b/crates/backend/src/pollers/triage.rs
@@ -233,6 +233,10 @@ pub async fn start_triage_task(pool: DbPool, auth_config: Arc<AuthConfig>, healt
 pub enum TriageCredential {
     /// Claude Code OAuth token from the in-app login (subscription auth)
     OAuthToken(String),
+    /// In-app login succeeded but the token wasn't capturable; the CLI
+    /// persisted its own credentials inside the container, so sessions
+    /// authenticate from disk with no env override
+    CliPersisted,
     /// ANTHROPIC_API_KEY inherited from the environment
     ApiKeyEnv,
 }
@@ -241,6 +245,7 @@ impl TriageCredential {
     fn source_name(&self) -> &'static str {
         match self {
             TriageCredential::OAuthToken(_) => "claude-code-login",
+            TriageCredential::CliPersisted => "claude-cli-persisted",
             TriageCredential::ApiKeyEnv => "api-key-env",
         }
     }
@@ -261,6 +266,12 @@ async fn detect_mode(pool: &DbPool) -> Result<TriageCredential, String> {
 
     if let Ok(mut conn) = pool.get().await {
         if let Ok(Some(cred)) = db::claude_credentials::get(&mut conn).await {
+            // Empty token = cli-persisted sentinel: the login succeeded but
+            // the token wasn't capturable; sessions use the CLI's own disk
+            // credentials (container-lifetime only)
+            if cred.oauth_token.is_empty() {
+                return Ok(TriageCredential::CliPersisted);
+            }
             return Ok(TriageCredential::OAuthToken(cred.oauth_token));
         }
     }


### PR DESCRIPTION
## Summary

Second-round login fix, downstream of `rust-code-agent-sdks` PR #259 (pin bumped to `828e520`). Matt's retry timed out with *neither* a token nor a rejection — the SDK session proved the crate's submit path sound at both timings, leaving two culprits this PR closes on the app side while the crate closes its own:

- **Paste sanitization before spending a login attempt**: strips all whitespace and the invisible-unicode set browsers inject on copy (ZWSP/ZWNJ/ZWJ/BOM — `trim()` touches none of the zero-widths). Empty-after-sanitize returns an immediate 400 *without consuming the flow* — the session stays alive for a clean re-paste. The log records the sanitized code length (never the content), so the next silent mystery arrives with a number.
- **`Error::LoginTimeout { transcript }`** (new in the crate): timeouts now return a 500 whose body carries the CLI's channel-diagnostics line + screen state — a timeout that names the stalled leg instead of presenting as generic silence. Submit-leg timeout raised 30s→90s per the SDK session's exchange-tail-latency analysis.
- **`credentials_updated`-without-token is a success, not a failure**: the CLI can accept the code and persist its own credentials while never exposing the token over the PTY. Stored as an empty-token sentinel; the pipeline gains a `CliPersisted` credential mode that *skips* the env-token override so sessions authenticate from the CLI's disk credentials, boot-logged as `credential=claude-cli-persisted` with an explicit WARN that container redeploys require re-login (HOME is ephemeral).
- Crate side also widened rejection detection to anchor on the retry-loop's structural `Press Enter to retry` marker, so mangled/unstable error wording (observed: `Requstfailed withstatus code 400…`) can no longer masquerade as silence.

## Testing
- Full workspace suite, clippy `-Dwarnings`, `--locked` build, migration-name check — clean
- Live third-attempt verification in prod after deploy (SHA-gated go-signal protocol with infrastructure)