### PR TITLE
Pin claude-codes 1b1749f: production-length codes now submit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "claude-codes"
 version = "2.1.220"
-source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=5f8d34dcc51ac82bd8ec76ddc741c6ee18d1f3da#5f8d34dcc51ac82bd8ec76ddc741c6ee18d1f3da"
+source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=1b1749f726112320143128879850ce03621e3884#1b1749f726112320143128879850ce03621e3884"
 dependencies = [
  "anyhow",
  "base64",

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -47,7 +47,7 @@ async-trait = "0.1.89"
 jsonwebtoken = "9"
 cookie = "0.18"
 google-calendar3 = "6.0.0"
-claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "5f8d34dcc51ac82bd8ec76ddc741c6ee18d1f3da", features = ["auth"] }
+claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "1b1749f726112320143128879850ce03621e3884", features = ["auth"] }
 tempfile = "3.27.0"
 
 # Pre-compressed static frontend assets (brotli/gzip, ETag/304, SPA fallback).


### PR DESCRIPTION
## Summary

Pin bump to `rust-code-agent-sdks` rev `1b1749f` ([PR #263](https://github.com/meawoppl/rust-code-agent-sdks/pull/263)) — the fix for login bug #3, the one that made attempts two and three time out identically.

**Root cause (characterized at the write site upstream):** single PTY writes ≥64 bytes are classified by the CLI as *pastes*, and the trailing CR is swallowed into the payload instead of acting as Enter. Real authorization codes are ~92 chars, so **no prior rev of the flow could ever submit a production-length code** — every test fixture any of us used sat under the threshold, so the flow passed every test and failed every real use. Not a regression; a launch bug that three rounds of instrumentation finally cornered (the channel line's `credentials=unchanged` + the sanitized-length log named the axis).

**The fix is two independent mechanisms** — bracketed-paste framing (the CLI advertises it) plus a lone CR 150ms later — so a future refactor must break both to reintroduce the bug. Upstream carries frame-shape unit tests at 64/92/108/120 bytes and a live integration test asserting 92- and 108-char codes produce `CodeRejected` within 15s against the real CLI. The guarantee is "production-length codes submit against the real CLI," with the CLI-owned threshold documented rather than asserted.

Zero API changes; handler and telemetry wiring untouched.

## Testing
- Full workspace suite, clippy `-Dwarnings`, `--locked` build — clean
- Live verification: Matt's fourth login attempt, SHA-gated by infrastructure