### PR TITLE
Log claude-codes rev at boot for deploy-gate provenance

### DIFF
--- a/crates/backend/build.rs
+++ b/crates/backend/build.rs
@@ -1,0 +1,39 @@
+//! Exposes the pinned claude-codes revision to the binary so boot logs can
+//! state build provenance. Binary string-grepping proved unsound for
+//! verifying deployed crate content (release LLVM inlines short byte
+//! literals into immediates), so the chain is asserted at the source:
+//! Cargo.lock -> compile-time env -> boot log line.
+
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../../Cargo.lock");
+
+    let lock = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../Cargo.lock"))
+        .unwrap_or_default();
+
+    let mut rev = String::from("unknown");
+    let mut in_claude_codes = false;
+    for line in lock.lines() {
+        if line.starts_with("[[package]]") {
+            in_claude_codes = false;
+        }
+        if line.trim() == "name = \"claude-codes\"" {
+            in_claude_codes = true;
+        }
+        if in_claude_codes && line.trim_start().starts_with("source = ") {
+            rev = match line.find("rev=") {
+                Some(i) => {
+                    let tail = &line[i + 4..];
+                    let end = tail.find(['#', '"']).unwrap_or(tail.len());
+                    tail[..end].to_string()
+                }
+                None => "crates-io".to_string(),
+            };
+            break;
+        }
+    }
+
+    println!("cargo:rustc-env=CLAUDE_CODES_REV={rev}");
+}

--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -464,7 +464,8 @@ pub async fn claude_auth_complete(
             // requires re-login.
             tracing::warn!(
                 "Claude login: succeeded via CLI-persisted credentials (token not \
-                 capturable; osc52={:?}); re-login will be needed after container redeploys",
+                 capturable; osc52={:?}); credentials persist only as durably as \
+                 ~/.claude does (persisted via volume on this deployment)",
                 outcome.osc52
             );
             String::new()

--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -209,6 +209,14 @@ async fn main() -> anyhow::Result<()> {
 
     dotenvy::dotenv().ok();
 
+    // Build provenance: which claude-codes rev this binary actually contains.
+    // Deploy gates read this line instead of grepping the binary, which can
+    // false-negative on optimized-out literals.
+    tracing::info!(
+        "Build provenance: claude-codes rev {}",
+        env!("CLAUDE_CODES_REV")
+    );
+
     let config = Config::from_env();
 
     // Migrations are embedded in the binary and applied before anything else


### PR DESCRIPTION
## Summary

Closes the verification gap attempt four exposed: binary string-grepping proved **unsound** for confirming deployed crate content — release LLVM inlines short byte literals (like the 6-byte paste-frame markers) into immediate instructions, so a grep can false-negative on code that is present and active. Both infra's container pull and the CI artifact showed zero frame bytes while a local release build from provably-fixed source showed the same zero.

- New `build.rs` extracts the pinned `claude-codes` rev from `Cargo.lock` at compile time; the backend logs `Build provenance: claude-codes rev <sha>` as its first boot line.
- Deploy gates can now assert the full chain (app commit **and** crate rev) from one log line instead of binary archaeology.
- Also softens the cli-persisted WARN, which claimed redeploys always require re-login — stale since infra placed the `~/.claude` persistence volume.

## Testing
- Verified live: local boot logs the exact pinned rev
- Full suite, clippy `-Dwarnings`, `--locked` — clean