### PR TITLE
Repin claude-codes to a7ab9b5 (TERM forcing + submit-path stamp)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "claude-codes"
 version = "2.1.220"
-source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=1b1749f726112320143128879850ce03621e3884#1b1749f726112320143128879850ce03621e3884"
+source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=a7ab9b5110cef43d937d7e850dbda23a787484f7#a7ab9b5110cef43d937d7e850dbda23a787484f7"
 dependencies = [
  "anyhow",
  "base64",
@@ -851,7 +851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2737,7 +2737,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3290,7 +3290,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4022,7 +4022,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -47,7 +47,7 @@ async-trait = "0.1.89"
 jsonwebtoken = "9"
 cookie = "0.18"
 google-calendar3 = "6.0.0"
-claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "1b1749f726112320143128879850ce03621e3884", features = ["auth"] }
+claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "a7ab9b5110cef43d937d7e850dbda23a787484f7", features = ["auth"] }
 tempfile = "3.27.0"
 
 # Pre-compressed static frontend assets (brotli/gzip, ETag/304, SPA fallback).


### PR DESCRIPTION
Bumps the git pin from 1b1749f to a7ab9b5, picking up SDK PR #265:

- Login child now runs with a forced TERM=xterm-256color instead of inheriting the backend's (absent) TERM — eliminates the last untested terminal-capability axis in prod.
- New SUBMIT_PATH constant stamped into every LoginTimeout channel line: which code-submission write path is deployed becomes readable from logs, no binary forensics.

Context: the deployed artifact was proven (via cargo checkout-path strings) to contain the 1b1749f framing fix, yet attempt four still failed. This rev makes the next attempt self-describing either way. Boot line will log the new rev on deploy.