### PR TITLE
Repin claude-codes to 0c0ee80 and bridge log-facade records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "urlencoding",
  "uuid",
@@ -428,7 +429,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "claude-codes"
 version = "2.1.220"
-source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=a7ab9b5110cef43d937d7e850dbda23a787484f7#a7ab9b5110cef43d937d7e850dbda23a787484f7"
+source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=0c0ee80fd1c3a25132a1a37766c86d5e89d6f218#0c0ee80fd1c3a25132a1a37766c86d5e89d6f218"
 dependencies = [
  "anyhow",
  "base64",
@@ -851,7 +852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2737,7 +2738,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3290,7 +3291,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4022,7 +4023,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -47,7 +47,7 @@ async-trait = "0.1.89"
 jsonwebtoken = "9"
 cookie = "0.18"
 google-calendar3 = "6.0.0"
-claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "a7ab9b5110cef43d937d7e850dbda23a787484f7", features = ["auth"] }
+claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "0c0ee80fd1c3a25132a1a37766c86d5e89d6f218", features = ["auth", "log"] }
 tempfile = "3.27.0"
 
 # Pre-compressed static frontend assets (brotli/gzip, ETag/304, SPA fallback).
@@ -57,6 +57,7 @@ memory-serve = "0.6"
 # with brotli-decompressor 4.0.3 (still on alloc-no-stdlib 2.x) inside
 # memory-serve's brotli 6. Holding 0.2.2 keeps the graph on one version.
 alloc-stdlib = "=0.2.2"
+tracing-log = "0.2.0"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -177,6 +177,12 @@ async fn main() -> anyhow::Result<()> {
         .install_default()
         .expect("Failed to install rustls crypto provider");
 
+    // Route log-facade records into tracing. claude-codes logs through `log`,
+    // and its "LoginFlow dropped while unfinished" warn is load-bearing login
+    // forensics: its absence must mean the drop didn't happen, not that the
+    // record was discarded. The registry() path installs no bridge on its own.
+    tracing_log::LogTracer::init().expect("Failed to install log-to-tracing bridge");
+
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()


### PR DESCRIPTION
Two changes, both in service of making login attempt five name its own failure:

- **Repin 1b1749f→a7ab9b5→0c0ee80** (SDK #267–#269): the crate previously held the PTY slave fd open in the parent, so the master could never read EOF and a dead CLI child ground the full 90s timeout — that is why four attempts produced identical benign-absence diagnostics. Child death is now a sub-second outcome with exit code; channel lines additionally stamp `child=alive|exited(code)` and `paste-mode@submit=on|off|never-advertised`.
- **Install `tracing_log::LogTracer`**: claude-codes logs via the `log` facade, and our `registry()`-based subscriber installs no bridge, so its records were silently discarded. The crate's new "LoginFlow dropped while unfinished" warn is load-bearing forensics — its absence must mean the drop didn't happen, not that the record went nowhere.

Exit-code map for the next attempt: small code = CLI self-exit, 143 = SIGTERM (Drop warn present ⇒ crate; absent ⇒ external), 137 = SIGKILL.