### PR TITLE
Fix boot panic from duplicate log-facade logger install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,6 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
  "urlencoding",
  "uuid",

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -57,7 +57,6 @@ memory-serve = "0.6"
 # with brotli-decompressor 4.0.3 (still on alloc-no-stdlib 2.x) inside
 # memory-serve's brotli 6. Holding 0.2.2 keeps the graph on one version.
 alloc-stdlib = "=0.2.2"
-tracing-log = "0.2.0"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -168,6 +168,24 @@ pub fn build_app(state: AppState, config: &Config) -> Router {
         .layer(config.cors_layer())
 }
 
+/// Install the global tracing subscriber, exactly once.
+///
+/// Do NOT add a separate `tracing_log::LogTracer::init()` here: `.init()`
+/// already installs the log-facade bridge (tracing-subscriber's default
+/// `tracing-log` feature), so log-crate records from dependencies such as
+/// claude-codes reach this subscriber. A second install returns
+/// `SetLoggerError`, which `.init()` unwraps into a panic before the server
+/// binds — that crash-looped production on 2026-08-03 (#106).
+fn init_tracing() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,tower_http=info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
@@ -177,19 +195,7 @@ async fn main() -> anyhow::Result<()> {
         .install_default()
         .expect("Failed to install rustls crypto provider");
 
-    // Route log-facade records into tracing. claude-codes logs through `log`,
-    // and its "LoginFlow dropped while unfinished" warn is load-bearing login
-    // forensics: its absence must mean the drop didn't happen, not that the
-    // record was discarded. The registry() path installs no bridge on its own.
-    tracing_log::LogTracer::init().expect("Failed to install log-to-tracing bridge");
-
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info,tower_http=info".into()),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
+    init_tracing();
 
     // Log panics with their source location and a backtrace via tracing, so
     // crashes are captured in structured logs rather than only on stderr.
@@ -379,6 +385,18 @@ mod tests {
     use diesel_async::pooled_connection::{deadpool::Pool, AsyncDieselConnectionManager};
     use diesel_async::AsyncPgConnection;
     use tower::ServiceExt;
+
+    /// Boot smoke test: init_tracing() performs two global installs (the
+    /// tracing dispatcher and, via tracing-subscriber's `tracing-log`
+    /// feature, the log-facade logger). Both are set-once process-wide, so a
+    /// duplicate install anywhere in the init path panics here the same way
+    /// it would in main() — which took production down on 2026-08-03 (#106)
+    /// with every CI check green. Keep this the ONLY test that installs a
+    /// subscriber.
+    #[test]
+    fn init_tracing_boots_without_panicking() {
+        init_tracing();
+    }
 
     /// State with a pool that is never actually connected. deadpool builds
     /// connections lazily, so routes that don't touch the database — asset


### PR DESCRIPTION
#106 crash-looped production on boot: `tracing_subscriber`'s `.init()` already installs the log-facade bridge (default `tracing-log` feature), so the explicit `LogTracer::init()` added there was a duplicate global install — the second one returns `SetLoggerError`, which `.init()` unwraps into a panic before the server ever binds. All 7 CI checks were green on a binary that could not start.

- Remove the redundant `LogTracer::init()` and the now-unused `tracing-log` dependency. The bridge the change was trying to guarantee **already existed** — claude-codes' log-facade records (including the load-bearing "LoginFlow dropped while unfinished" warn) reach our subscriber via `.init()` itself. A comment on `init_tracing()` pins why no second install may ever be added.
- Extract `init_tracing()` and add a boot smoke test that executes it in-process: both global installs fire in the test exactly as in `main()`, so any future duplicate-install regression fails CI instead of crash-looping prod.

Infra has prod pinned to `sha-befcb38` with watchtower disabled pending this fix.