### PR TITLE
Make rejected login codes terminal and guard against URL pastes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "claude-codes"
 version = "2.1.220"
-source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=0c0ee80fd1c3a25132a1a37766c86d5e89d6f218#0c0ee80fd1c3a25132a1a37766c86d5e89d6f218"
+source = "git+https://github.com/meawoppl/rust-code-agent-sdks?rev=e2be23ce7249be359ec28ff02cae4c0c5c5cea17#e2be23ce7249be359ec28ff02cae4c0c5c5cea17"
 dependencies = [
  "anyhow",
  "base64",
@@ -851,7 +851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2737,7 +2737,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3290,7 +3290,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4022,7 +4022,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -47,7 +47,7 @@ async-trait = "0.1.89"
 jsonwebtoken = "9"
 cookie = "0.18"
 google-calendar3 = "6.0.0"
-claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "0c0ee80fd1c3a25132a1a37766c86d5e89d6f218", features = ["auth", "log"] }
+claude-codes = { git = "https://github.com/meawoppl/rust-code-agent-sdks", rev = "e2be23ce7249be359ec28ff02cae4c0c5c5cea17", features = ["auth", "log"] }
 tempfile = "3.27.0"
 
 # Pre-compressed static frontend assets (brotli/gzip, ETag/304, SPA fallback).

--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -413,15 +413,15 @@ pub async fn claude_auth_complete(
     let outcome = match outcome {
         Ok(outcome) => outcome,
         Err(claude_codes::Error::CodeRejected { message }) => {
-            // The CLI is alive awaiting a retry against the same PKCE
-            // verifier; put the flow back so a corrected paste reaches it
+            // A rejected code is terminal for this CLI session: the error
+            // screen renders no input component, and Enter restarts the OAuth
+            // flow with a fresh PKCE verifier — a corrected paste has nowhere
+            // to land (read out of the Ink state machine and verified against
+            // the live CLI). Kill the child; the UI starts a new login.
             tracing::warn!("Claude login: code rejected by CLI: {message}");
-            *state
-                .claude_login
-                .lock()
-                .expect("claude_login mutex poisoned") = Some((flow, started));
+            drop(flow);
             return Err(ApiError::BadRequest(format!(
-                "Code rejected: {message} - check the paste and try again"
+                "Code rejected: {message} - start a new login and paste the fresh code"
             )));
         }
         Err(claude_codes::Error::LoginTimeout { transcript }) => {

--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -2463,7 +2463,25 @@ fn claude_auth_card() -> Html {
         let error = error.clone();
         let refresh = refresh_status.clone();
         Callback::from(move |_| {
-            let body = serde_json::json!({ "code": (*code).clone() });
+            // Catch the classic mispaste (the authorize URL, or URL + code)
+            // before it costs a round trip and kills the CLI session. Real
+            // codes are ~92 chars and never contain a scheme.
+            let pasted = code.trim().to_string();
+            if pasted.starts_with("http://") || pasted.starts_with("https://") {
+                error.set(Some(
+                    "That looks like the URL - paste the code shown on that page instead"
+                        .to_string(),
+                ));
+                return;
+            }
+            if pasted.len() > 150 {
+                error.set(Some(format!(
+                    "That's {} characters - the code is ~92. Paste just the code, not the whole page",
+                    pasted.len()
+                )));
+                return;
+            }
+            let body = serde_json::json!({ "code": pasted });
             let code = code.clone();
             let auth_url = auth_url.clone();
             let busy = busy.clone();
@@ -2484,14 +2502,11 @@ fn claude_auth_card() -> Html {
                         code.set(String::new());
                         refresh.emit(());
                     }
-                    Ok(resp) if resp.status() == 400 => {
-                        // Code rejected: the same login session is still alive
-                        // awaiting a corrected paste, so keep the URL + input
-                        let text = resp.text().await.unwrap_or_default();
-                        error.set(Some(text));
-                    }
                     Ok(resp) => {
-                        // Fatal (expired flow, CLI failure): reset to step one
+                        // Any failure resets to step one. A rejected code is
+                        // terminal for the CLI session (its error screen has
+                        // no input field), so the old URL + input would offer
+                        // a retry that cannot work.
                         let text = resp.text().await.unwrap_or_default();
                         auth_url.set(None);
                         code.set(String::new());
@@ -2524,11 +2539,11 @@ fn claude_auth_card() -> Html {
                     <div class="claude-auth-flow">
                         <p>{"1. Open this link and sign in to Claude:"}</p>
                         <p><a href={url.clone()} target="_blank" rel="noopener">{url}</a></p>
-                        <p>{"2. Paste the code you receive:"}</p>
+                        <p>{"2. Paste the code shown on that page (just the code, not the URL):"}</p>
                         <div class="claude-auth-code-row">
                             <input
                                 type="text"
-                                placeholder="Paste code here"
+                                placeholder="Paste the ~92-character code"
                                 value={(*code).clone()}
                                 oninput={on_code_input}
                             />


### PR DESCRIPTION
Login works in production as of tonight — this PR removes the two traps the successful attempt exposed:

- **Rejected codes are terminal.** The CLI's error screen has no input field, and Enter restarts OAuth with a rotated PKCE verifier (infra read the Ink state machine out of the binary and live-verified both retry variants write into nothing). The handler now kills the CLI child on `CodeRejected` and the UI resets to step one on any failure, instead of keeping an input+URL that imply a retry the CLI cannot honor.
- **Mispaste guard.** The first paste tonight was 346 chars (the URL); the code is ~92. The input now says to paste the code, not the URL, and warns client-side on URL-shaped or >150-char values before any round trip — each of which would otherwise cost a full login restart under the new terminal semantics.
- **Repin claude-codes 0c0ee80 → e2be23c** (SDK #270): `submit_code` returns `InvalidState` on a blind re-paste and `retry_new_url()` exists for flows that want the Enter-through-retry path; we take the simpler drop-and-restart contract this PR implements.