### PR TITLE
Rapid-accept archive bundles, Gmail backfill, past-event triage

### DIFF
--- a/crates/backend/src/db.rs
+++ b/crates/backend/src/db.rs
@@ -362,6 +362,22 @@ pub mod emails {
         Ok(count)
     }
 
+    /// Oldest received timestamp stored for an account — the starting point
+    /// for walking the mailbox history backwards during backfill
+    pub async fn oldest_received_at(
+        conn: &mut AsyncPgConnection,
+        account: Uuid,
+    ) -> anyhow::Result<Option<chrono::DateTime<chrono::Utc>>> {
+        use crate::schema::emails::dsl::*;
+
+        let oldest = emails
+            .filter(account_id.eq(account))
+            .select(diesel::dsl::min(received_at))
+            .get_result::<Option<chrono::DateTime<chrono::Utc>>>(conn)
+            .await?;
+        Ok(oldest)
+    }
+
     /// Insert a new email, returning None if this account already has it.
     /// Gmail ids are only unique per mailbox, so the conflict target must be
     /// (account_id, gmail_id) — matching the table's unique constraint.

--- a/crates/backend/src/pollers/email.rs
+++ b/crates/backend/src/pollers/email.rs
@@ -98,6 +98,11 @@ impl RateLimiter {
 #[derive(Debug, Clone, Default)]
 struct AccountState {
     last_history_id: Option<u64>,
+    /// Walks backwards through inbox history one batch per cycle; seeded
+    /// from the oldest stored email, so a restart resumes near where it left
+    /// off (dedupe absorbs the overlap)
+    backfill_cursor: Option<chrono::DateTime<chrono::Utc>>,
+    backfill_done: bool,
 }
 
 /// Start the email polling background task
@@ -266,7 +271,7 @@ struct PollResult {
 
 async fn poll_single_account(
     account: &GoogleAccount,
-    state: &AccountState,
+    state: &mut AccountState,
     pool: &DbPool,
     max_fetch_per_poll: u32,
 ) -> Result<PollResult> {
@@ -285,12 +290,74 @@ async fn poll_single_account(
         _ => client.fetch_messages(max_fetch_per_poll).await?,
     };
 
-    let count = save_emails_to_db(&emails, account.id, pool).await?;
+    let mut count = save_emails_to_db(&emails, account.id, pool).await?;
+    count += backfill_older_messages(account, state, &client, pool, max_fetch_per_poll).await?;
 
     // Get current history ID for next sync
     let history_id = client.get_history_id().await.ok();
 
     Ok(PollResult { count, history_id })
+}
+
+/// Walk the inbox history backwards one batch per cycle until exhausted, so
+/// triage extends indefinitely into the past. The cursor only ever moves
+/// backwards; (account_id, gmail_id) dedupe makes fetch overlap harmless.
+async fn backfill_older_messages(
+    account: &GoogleAccount,
+    state: &mut AccountState,
+    client: &GmailClient,
+    pool: &DbPool,
+    max_fetch_per_poll: u32,
+) -> Result<usize> {
+    if state.backfill_done {
+        return Ok(0);
+    }
+
+    let cursor = match state.backfill_cursor {
+        Some(c) => Some(c),
+        None => {
+            let mut conn = pool.get().await.context("Failed to get DB connection")?;
+            db::emails::oldest_received_at(&mut conn, account.id).await?
+        }
+    };
+    // Nothing stored yet: let the initial forward fetch land first
+    let Some(cursor) = cursor else { return Ok(0) };
+
+    let older = client
+        .fetch_messages_before(cursor.timestamp(), max_fetch_per_poll)
+        .await?;
+
+    if older.is_empty() {
+        state.backfill_done = true;
+        tracing::info!(
+            "Backfill complete for {}: inbox history exhausted at {}",
+            account.email,
+            cursor
+        );
+        return Ok(0);
+    }
+
+    let count = save_emails_to_db(&older, account.id, pool).await?;
+
+    // Advance strictly backwards even if every fetched message was already
+    // stored (header dates can postdate Gmail's internal date, which is what
+    // `before:` matches on) — otherwise the cursor would stall forever
+    let oldest_fetched = older.iter().filter_map(|e| e.received_at).min();
+    let next = match oldest_fetched {
+        Some(t) if t < cursor => t,
+        _ => cursor - chrono::Duration::seconds(1),
+    };
+    state.backfill_cursor = Some(next);
+
+    tracing::info!(
+        "Backfilled {} older emails from {} ({} fetched, cursor now {})",
+        count,
+        account.email,
+        older.len(),
+        next
+    );
+
+    Ok(count)
 }
 
 async fn save_emails_to_db(

--- a/crates/backend/src/pollers/gmail_client.rs
+++ b/crates/backend/src/pollers/gmail_client.rs
@@ -105,6 +105,43 @@ impl GmailClient {
         Ok(emails)
     }
 
+    /// Fetch inbox messages received strictly before the given epoch second
+    /// (history backfill). Gmail's `before:` operator matches on internal
+    /// date and returns newest-first, so repeated calls with a descending
+    /// cursor walk the inbox history backwards until exhausted.
+    pub async fn fetch_messages_before(
+        &self,
+        before_epoch_secs: i64,
+        max_results: u32,
+    ) -> Result<Vec<EmailMessage>> {
+        let (_, list_response) = self
+            .hub
+            .users()
+            .messages_list("me")
+            .add_label_ids("INBOX")
+            .q(&format!("before:{before_epoch_secs}"))
+            .max_results(max_results)
+            .doit()
+            .await
+            .context("Failed to list backfill messages")?;
+
+        let messages = list_response.messages.unwrap_or_default();
+        let mut emails = Vec::new();
+
+        for msg in messages {
+            if let Some(id) = msg.id {
+                match self.get_message(&id).await {
+                    Ok(email) => emails.push(email),
+                    Err(e) => {
+                        tracing::warn!("Failed to fetch message {}: {}", id, e);
+                    }
+                }
+            }
+        }
+
+        Ok(emails)
+    }
+
     /// Fetch messages since a history ID (incremental sync)
     pub async fn fetch_messages_since(
         &self,

--- a/crates/backend/src/pollers/triage.rs
+++ b/crates/backend/src/pollers/triage.rs
@@ -108,6 +108,9 @@ Dispositions:
   agent-cli decide event --email-id <id> --summary "<title>" --start <rfc3339> --end <rfc3339> [--location "<loc>"] [--description "<details>"] --reasoning "<why>"
   If the timezone is unclear, assume America/Los_Angeles. If no end time is
   given, assume one hour after the start.
+  Only propose events whose date is in the FUTURE relative to today's date
+  (given below the emails count). An event, opportunity, or deadline that has
+  already passed is an archive candidate, not an event — the moment is gone.
 - Requires the user to act, reply, decide, or follow up:
   agent-cli decide queue-action --email-id <id> --reasoning "<why>"
 - Personal or potentially important, but nothing to do right now:
@@ -129,8 +132,11 @@ agent-cli via Bash:
 Be conservative: personal correspondence, money, legal, medical, childcare,
 travel, or anything that reads like a human wrote it to the user specifically
 should be kept. Bulk mail, marketing, and automated notifications with no
-action should be archived. One call per email; do not skip any. Finish with a
-one-line summary."#;
+action should be archived. Emails about events, opportunities, or deadlines
+whose date has already passed (relative to today's date, given below the
+emails count) should be archived even if they once mattered — unless they
+still require follow-up from the user. One call per email; do not skip any.
+Finish with a one-line summary."#;
 
 const ACTION_INSTRUCTIONS: &str = r#"You are the action stage of an email triage pipeline: you decide what belongs
 on the user's todo list.
@@ -432,9 +438,12 @@ async fn run_stage(
         .await
         .context("Failed to start claude session")?;
 
+    // The date matters: the backlog extends indefinitely into the past, and
+    // several dispositions hinge on whether an event date has already gone by
     let prompt = format!(
-        "{instructions}\n\nThere are {} emails in ./emails.json.",
-        emails.len()
+        "{instructions}\n\nThere are {} emails in ./emails.json. Today's date is {} (UTC).",
+        emails.len(),
+        Utc::now().format("%Y-%m-%d")
     );
 
     let result = tokio::time::timeout(timeout, client.query(&prompt)).await;

--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -1,11 +1,12 @@
 use gloo_net::http::Request;
 use shared_types::{
-    AboutMeResponse, AgentDecisionResponse, ApproveDecisionRequest, AuthUserResponse,
-    BatchApproveDecisionsRequest, BatchRejectDecisionsRequest, CalendarEventResponse, Category,
-    ChatMessageResponse, ChatResponse, ClaudeAuthStatusResponse, CreateTodoRequest, DecisionStats,
-    EmailResponse, GoogleAccountResponse, LoginInitResponse, PipelineStatsResponse,
-    ProposedCalendarEventAction, ProposedTodoAction, RejectDecisionRequest, SendChatMessageRequest,
-    SuggestedAction, Todo, UpdateAboutMeRequest, UpdateTodoRequest,
+    AboutMeResponse, AgentDecisionResponse, ApproveDecisionRequest, ArchiveReviewItem,
+    ArchiveReviewResponse, AuthUserResponse, BatchApproveDecisionsRequest, BatchOperationResponse,
+    BatchRejectDecisionsRequest, CalendarEventResponse, Category, ChatMessageResponse,
+    ChatResponse, ClaudeAuthStatusResponse, CreateTodoRequest, DecisionStats, EmailResponse,
+    GoogleAccountResponse, LoginInitResponse, PipelineStatsResponse, ProposedCalendarEventAction,
+    ProposedTodoAction, RejectDecisionRequest, SendChatMessageRequest, SuggestedAction, Todo,
+    UpdateAboutMeRequest, UpdateTodoRequest,
 };
 use uuid::Uuid;
 use web_sys::{Element, HtmlInputElement};
@@ -34,6 +35,7 @@ pub enum AuthState {
 #[derive(Clone, PartialEq, Copy)]
 pub enum View {
     Inbox,
+    Review,
     Todos,
     Calendar,
     DecisionLog,
@@ -536,6 +538,11 @@ fn authenticated_app(props: &AuthenticatedAppProps) -> Html {
         Callback::from(move |_| set_view.emit(View::Pipeline))
     };
 
+    let set_view_review = {
+        let set_view = ctx.set_view.clone();
+        Callback::from(move |_| set_view.emit(View::Review))
+    };
+
     let set_view_about_me = {
         let set_view = ctx.set_view.clone();
         Callback::from(move |_| set_view.emit(View::AboutMe))
@@ -571,6 +578,12 @@ fn authenticated_app(props: &AuthenticatedAppProps) -> Html {
                         } else {
                             html! {}
                         }}
+                    </button>
+                    <button
+                        class={if current_view == View::Review { "nav-btn active" } else { "nav-btn" }}
+                        onclick={set_view_review}
+                    >
+                        {"Review"}
                     </button>
                     <button
                         class={if current_view == View::Todos { "nav-btn active" } else { "nav-btn" }}
@@ -613,6 +626,7 @@ fn authenticated_app(props: &AuthenticatedAppProps) -> Html {
             <main>
                 {match current_view {
                     View::Inbox => html! { <DecisionInbox /> },
+                    View::Review => html! { <ArchiveReviewPanel /> },
                     View::Todos => html! { <TodoList /> },
                     View::Calendar => html! { <CalendarView /> },
                     View::DecisionLog => html! { <DecisionLog /> },
@@ -2573,6 +2587,398 @@ fn claude_auth_card() -> Html {
                         </button>
                     </div>
                 },
+            }}
+        </div>
+    }
+}
+
+// ============================================================================
+// Archive Review: bundled rapid-accept
+// ============================================================================
+
+/// Monotonic bundle keys. Generated at dispatch sites (not in the reducer)
+/// so the failure path can schedule its re-enable timer against a known key.
+static NEXT_BUNDLE_KEY: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+fn next_bundle_key() -> usize {
+    NEXT_BUNDLE_KEY.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
+const REVIEW_BUNDLE_SIZE: usize = 10;
+/// How long a returned bundle's buttons stay disabled after a failed accept
+const RETURNED_BUNDLE_COOLDOWN_MS: u32 = 4_000;
+
+#[derive(Clone, PartialEq)]
+struct ReviewBundle {
+    key: usize,
+    items: Vec<ArchiveReviewItem>,
+    /// Came back after a failed accept
+    returned: bool,
+    /// Server error from the failed accept, shown on the card
+    error: Option<String>,
+}
+
+#[derive(PartialEq, Default)]
+struct ReviewQueue {
+    bundles: Vec<ReviewBundle>,
+    /// Bundle keys whose buttons are in the post-failure cooldown
+    disabled: std::collections::HashSet<usize>,
+    archive_mode: String,
+    loaded: bool,
+    banner: Option<String>,
+}
+
+enum ReviewMsg {
+    Loaded {
+        mode: String,
+        bundles: Vec<ReviewBundle>,
+    },
+    LoadFailed(String),
+    /// Optimistic accept: the front bundle disappears immediately
+    PopFront,
+    /// Failed accept: items rejoin at the back of the queue, disabled for a
+    /// cooldown so the rapid-click flow isn't interrupted by a dead retry
+    ReturnBundle {
+        key: usize,
+        items: Vec<ArchiveReviewItem>,
+        error: String,
+    },
+    CooldownOver(usize),
+    /// Per-item keep (optimistic)
+    RemoveItem {
+        bundle_key: usize,
+        decision_id: Uuid,
+    },
+    /// Drop a permanently-failing returned bundle without a backend call
+    DismissBundle(usize),
+    Banner(Option<String>),
+}
+
+impl Reducible for ReviewQueue {
+    type Action = ReviewMsg;
+
+    fn reduce(self: std::rc::Rc<Self>, msg: ReviewMsg) -> std::rc::Rc<Self> {
+        let mut next = ReviewQueue {
+            bundles: self.bundles.clone(),
+            disabled: self.disabled.clone(),
+            archive_mode: self.archive_mode.clone(),
+            loaded: self.loaded,
+            banner: self.banner.clone(),
+        };
+        match msg {
+            ReviewMsg::Loaded { mode, bundles } => {
+                next.archive_mode = mode;
+                next.bundles = bundles;
+                next.disabled.clear();
+                next.loaded = true;
+                next.banner = None;
+            }
+            ReviewMsg::LoadFailed(e) => {
+                next.loaded = true;
+                next.banner = Some(e);
+            }
+            ReviewMsg::PopFront => {
+                if !next.bundles.is_empty() {
+                    next.bundles.remove(0);
+                }
+            }
+            ReviewMsg::ReturnBundle { key, items, error } => {
+                next.disabled.insert(key);
+                next.banner = Some(format!(
+                    "{} email(s) couldn't be archived - returned to the back of the queue",
+                    items.len()
+                ));
+                next.bundles.push(ReviewBundle {
+                    key,
+                    items,
+                    returned: true,
+                    error: Some(error),
+                });
+            }
+            ReviewMsg::CooldownOver(key) => {
+                next.disabled.remove(&key);
+            }
+            ReviewMsg::RemoveItem {
+                bundle_key,
+                decision_id,
+            } => {
+                for b in &mut next.bundles {
+                    if b.key == bundle_key {
+                        b.items.retain(|i| i.decision_id != decision_id);
+                    }
+                }
+                next.bundles.retain(|b| !b.items.is_empty());
+            }
+            ReviewMsg::DismissBundle(key) => {
+                next.bundles.retain(|b| b.key != key);
+                next.disabled.remove(&key);
+            }
+            ReviewMsg::Banner(b) => next.banner = b,
+        }
+        next.into()
+    }
+}
+
+/// One-place rapid accept over archive proposals, in bundles of ten. Accept
+/// removes the bundle instantly and fires the backend work; anything the
+/// backend couldn't archive animates back into the queue.
+#[function_component(ArchiveReviewPanel)]
+fn archive_review_panel() -> Html {
+    let queue = use_reducer(ReviewQueue::default);
+
+    let load = {
+        let queue = queue.clone();
+        Callback::from(move |_: ()| {
+            let queue = queue.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                match Request::get("/api/pipeline/archive-review").send().await {
+                    Ok(resp) if resp.ok() => match resp.json::<ArchiveReviewResponse>().await {
+                        Ok(data) => {
+                            let bundles = data
+                                .items
+                                .chunks(REVIEW_BUNDLE_SIZE)
+                                .map(|chunk| ReviewBundle {
+                                    key: next_bundle_key(),
+                                    items: chunk.to_vec(),
+                                    returned: false,
+                                    error: None,
+                                })
+                                .collect();
+                            queue.dispatch(ReviewMsg::Loaded {
+                                mode: data.archive_mode,
+                                bundles,
+                            });
+                        }
+                        Err(e) => {
+                            queue.dispatch(ReviewMsg::LoadFailed(format!("Bad response: {e}")))
+                        }
+                    },
+                    Ok(resp) => queue.dispatch(ReviewMsg::LoadFailed(format!(
+                        "API error: {}",
+                        resp.status()
+                    ))),
+                    Err(e) => queue.dispatch(ReviewMsg::LoadFailed(format!("Request failed: {e}"))),
+                }
+            });
+        })
+    };
+
+    {
+        let load = load.clone();
+        use_effect_with((), move |_| {
+            load.emit(());
+            || ()
+        });
+    }
+
+    let on_accept = {
+        let queue = queue.clone();
+        Callback::from(move |_| {
+            let Some(front) = queue.bundles.first() else {
+                return;
+            };
+            if queue.disabled.contains(&front.key) {
+                return;
+            }
+            let items = front.items.clone();
+            let ids: Vec<Uuid> = items.iter().map(|i| i.decision_id).collect();
+            // Optimistic: the bundle is gone before the network is involved,
+            // so the next bundle is already under the cursor
+            queue.dispatch(ReviewMsg::PopFront);
+            let queue = queue.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let request = BatchApproveDecisionsRequest { decision_ids: ids };
+                let outcome = match Request::post("/api/decisions/batch/approve")
+                    .header("Content-Type", "application/json")
+                    .body(serde_json::to_string(&request).unwrap())
+                    .expect("body")
+                    .send()
+                    .await
+                {
+                    Ok(resp) if resp.ok() => match resp.json::<BatchOperationResponse>().await {
+                        Ok(out) if out.failed.is_empty() => Ok(()),
+                        Ok(out) => {
+                            let failed_ids: std::collections::HashSet<Uuid> =
+                                out.failed.iter().map(|f| f.id).collect();
+                            let error = out
+                                .failed
+                                .first()
+                                .map(|f| f.error.clone())
+                                .unwrap_or_default();
+                            let failed_items: Vec<ArchiveReviewItem> = items
+                                .into_iter()
+                                .filter(|i| failed_ids.contains(&i.decision_id))
+                                .collect();
+                            Err((failed_items, error))
+                        }
+                        // The server said ok but the body didn't parse: the
+                        // approvals executed, so returning items would only
+                        // set up doomed retries
+                        Err(e) => {
+                            queue.dispatch(ReviewMsg::Banner(Some(format!(
+                                "Accepted, but the response was unreadable: {e}"
+                            ))));
+                            Ok(())
+                        }
+                    },
+                    Ok(resp) => Err((items, format!("server error {}", resp.status()))),
+                    Err(e) => Err((items, format!("request failed: {e}"))),
+                };
+                if let Err((failed_items, error)) = outcome {
+                    let key = next_bundle_key();
+                    queue.dispatch(ReviewMsg::ReturnBundle {
+                        key,
+                        items: failed_items,
+                        error,
+                    });
+                    let queue = queue.clone();
+                    gloo::timers::callback::Timeout::new(RETURNED_BUNDLE_COOLDOWN_MS, move || {
+                        queue.dispatch(ReviewMsg::CooldownOver(key));
+                    })
+                    .forget();
+                }
+            });
+        })
+    };
+
+    let on_keep = {
+        let queue = queue.clone();
+        Callback::from(move |(bundle_key, decision_id): (usize, Uuid)| {
+            queue.dispatch(ReviewMsg::RemoveItem {
+                bundle_key,
+                decision_id,
+            });
+            let queue = queue.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let request = BatchRejectDecisionsRequest {
+                    decision_ids: vec![decision_id],
+                    feedback: None,
+                };
+                let failed = match Request::post("/api/decisions/batch/reject")
+                    .header("Content-Type", "application/json")
+                    .body(serde_json::to_string(&request).unwrap())
+                    .expect("body")
+                    .send()
+                    .await
+                {
+                    Ok(resp) => !resp.ok(),
+                    Err(_) => true,
+                };
+                if failed {
+                    queue.dispatch(ReviewMsg::Banner(Some(
+                        "Keep didn't reach the server - that email is still proposed for archive"
+                            .to_string(),
+                    )));
+                }
+            });
+        })
+    };
+
+    let total_emails: usize = queue.bundles.iter().map(|b| b.items.len()).sum();
+    let front = queue.bundles.first().cloned();
+    let front_disabled = front
+        .as_ref()
+        .map(|b| queue.disabled.contains(&b.key))
+        .unwrap_or(true);
+
+    html! {
+        <div class="archive-review">
+            <div class="view-header">
+                <h2>{"Archive Review"}</h2>
+                {if queue.archive_mode == "propose" {
+                    html! { <span class="mode-badge mode-dry-run" title="The agent only proposes; accepting a bundle is what archives those emails in Gmail">{"dry-run"}</span> }
+                } else if !queue.archive_mode.is_empty() {
+                    html! { <span class="mode-badge mode-execute">{&queue.archive_mode}</span> }
+                } else {
+                    html! {}
+                }}
+                <button class="btn-secondary" onclick={let load = load.clone(); Callback::from(move |_| load.emit(()))}>
+                    {"Refresh"}
+                </button>
+            </div>
+            {if let Some(msg) = queue.banner.clone() {
+                html! { <div class="review-banner">{msg}</div> }
+            } else {
+                html! {}
+            }}
+            {match front {
+                None if !queue.loaded => html! { <p class="empty-state">{"Loading proposals..."}</p> },
+                None => html! {
+                    <p class="empty-state">{"Nothing awaiting review. The agent will keep proposing as the backlog drains."}</p>
+                },
+                Some(bundle) => {
+                    let bundle_key = bundle.key;
+                    html! {
+                        <>
+                            <div class="rapid-accept-bar">
+                                <button
+                                    class="btn-approve accept-big-btn"
+                                    disabled={front_disabled}
+                                    onclick={on_accept.clone()}
+                                >
+                                    {format!("Archive these {}", bundle.items.len())}
+                                </button>
+                                <span class="review-progress">
+                                    {format!("{} emails in {} bundles remaining", total_emails, queue.bundles.len())}
+                                </span>
+                            </div>
+                            <div class={if bundle.returned { "review-bundle-card bundle-returned" } else { "review-bundle-card" }}>
+                                {if let Some(err) = bundle.error.clone() {
+                                    html! {
+                                        <div class="bundle-error-note">
+                                            {format!("Returned after a failed attempt: {err}")}
+                                            <button
+                                                class="btn-secondary"
+                                                disabled={front_disabled}
+                                                onclick={let queue = queue.clone(); Callback::from(move |_| queue.dispatch(ReviewMsg::DismissBundle(bundle_key)))}
+                                            >
+                                                {"Dismiss bundle"}
+                                            </button>
+                                        </div>
+                                    }
+                                } else {
+                                    html! {}
+                                }}
+                                {for bundle.items.iter().map(|item| {
+                                    let keep = on_keep.clone();
+                                    let decision_id = item.decision_id;
+                                    html! {
+                                        <div class="review-item-row" key={item.decision_id.to_string()}>
+                                            <div class="review-item-main">
+                                                <span class="review-item-from">
+                                                    {item.from_name.clone().unwrap_or_else(|| item.from_address.clone())}
+                                                </span>
+                                                <span class="review-item-subject">{&item.subject}</span>
+                                                <span class="review-item-reason" title={item.reasoning.clone()}>
+                                                    {&item.reasoning}
+                                                </span>
+                                            </div>
+                                            <span class="review-item-date">
+                                                {item.received_at.format("%Y-%m-%d").to_string()}
+                                            </span>
+                                            <button
+                                                class="btn-secondary review-keep-btn"
+                                                disabled={front_disabled}
+                                                onclick={Callback::from(move |_| keep.emit((bundle_key, decision_id)))}
+                                            >
+                                                {"Keep"}
+                                            </button>
+                                        </div>
+                                    }
+                                })}
+                            </div>
+                            {if queue.bundles.len() > 1 {
+                                html! {
+                                    <p class="review-queue-hint">
+                                        {format!("{} more bundles queued behind this one", queue.bundles.len() - 1)}
+                                    </p>
+                                }
+                            } else {
+                                html! {}
+                            }}
+                        </>
+                    }
+                }
             }}
         </div>
     }

--- a/crates/frontend/styles.css
+++ b/crates/frontend/styles.css
@@ -2099,3 +2099,178 @@ main {
     z-index: 99;
     background: transparent;
 }
+
+/* ============================================================
+   Archive Review: bundled rapid-accept
+   ============================================================ */
+
+.archive-review .view-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.mode-badge {
+    padding: 3px 10px;
+    border-radius: 10px;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.mode-dry-run {
+    background-color: #fef5e7;
+    color: #b9770e;
+    border: 1px solid #f5cba7;
+}
+
+.mode-execute {
+    background-color: #eafaf1;
+    color: #1e8449;
+    border: 1px solid #a9dfbf;
+}
+
+.review-banner {
+    background-color: #fdf2e9;
+    border-left: 4px solid #e67e22;
+    padding: 10px 14px;
+    border-radius: 4px;
+    margin-bottom: 12px;
+    font-size: 14px;
+    animation: review-slide-in 0.3s ease-out;
+}
+
+/* The one place to click: sticky so the button never moves while bundles
+   flow underneath it */
+.rapid-accept-bar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    background-color: #fff;
+    padding: 14px 16px;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+    margin-bottom: 12px;
+}
+
+.accept-big-btn {
+    font-size: 17px;
+    font-weight: 600;
+    padding: 14px 34px;
+    border-radius: 6px;
+}
+
+.accept-big-btn:disabled {
+    background-color: #a9dfbf;
+    cursor: not-allowed;
+}
+
+.review-progress {
+    color: #7f8c8d;
+    font-size: 14px;
+}
+
+.review-bundle-card {
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    padding: 8px 16px;
+}
+
+/* A bundle that came back after a failed accept slides in and glows amber */
+.bundle-returned {
+    border-left: 4px solid #e67e22;
+    animation: review-slide-in 0.45s ease-out;
+}
+
+@keyframes review-slide-in {
+    from {
+        opacity: 0;
+        transform: translateY(-14px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.bundle-error-note {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    background-color: #fdf2e9;
+    border-radius: 4px;
+    padding: 8px 12px;
+    margin: 8px 0;
+    font-size: 13px;
+    color: #b9770e;
+}
+
+.review-item-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 0;
+    border-bottom: 1px solid #ecf0f1;
+}
+
+.review-item-row:last-child {
+    border-bottom: none;
+}
+
+.review-item-main {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.review-item-from {
+    font-weight: 600;
+    font-size: 13px;
+    color: #2c3e50;
+}
+
+.review-item-subject {
+    font-size: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.review-item-reason {
+    font-size: 12px;
+    color: #95a5a6;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.review-item-date {
+    font-size: 12px;
+    color: #7f8c8d;
+    white-space: nowrap;
+}
+
+.review-keep-btn {
+    flex-shrink: 0;
+}
+
+.review-keep-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.review-queue-hint {
+    text-align: center;
+    color: #95a5a6;
+    font-size: 13px;
+    margin-top: 12px;
+}


### PR DESCRIPTION
Three pieces toward "just click accept, rapidly":

**Review tab (new).** Archive proposals arrive in bundles of 10 behind one big Accept button in a sticky bar — the button never moves; bundles flow underneath it. Accept is optimistic: the bundle disappears immediately and the batch approve fires in the background. If the backend can't archive some of them, those items slide back into the queue (amber, animated) with their buttons on a 4s cooldown and the server's error shown on the card — the failure rejoins at the *back* of the queue so rapid clicking never stalls on a dead retry. Per-item **Keep** rejects a single proposal; permanently failing bundles get a **Dismiss**. The dry-run badge clarifies that accepting is what actually archives.

**Indefinite backfill.** The poller now walks each inbox's history backwards one batch per cycle using Gmail's `before:` query, cursor seeded from the oldest stored email and stepped strictly backwards (header-vs-internal date skew can't stall it). Stops when Gmail returns nothing older. Existing `(account_id, gmail_id)` dedupe absorbs overlap; restarts resume from the DB.

**Past-event awareness.** Stage prompts now include today's date. Screening only proposes calendar events dated in the future — a passed event/opportunity/deadline is an archive candidate. The archive stage may archive anything whose moment has gone, unless follow-up is still needed. Without this, backfilled 2025 invitations would have become calendar proposals.