### PR TITLE
Hover tooltip with message body on archive review rows

### DIFF
--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -543,6 +543,11 @@ pub async fn get_archive_review(
                 from_name: email.from_name.clone(),
                 received_at: email.received_at,
                 snippet: email.snippet.clone(),
+                body_preview: email.body_text.as_ref().map(|b| {
+                    // Char-boundary-safe truncation; bodies can be huge and
+                    // 500 items ship in one response
+                    b.chars().take(1200).collect()
+                }),
             })
         })
         .collect();

--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -2936,6 +2936,13 @@ fn archive_review_panel() -> Html {
                                 {for bundle.items.iter().map(|item| {
                                     let keep = on_keep.clone();
                                     let decision_id = item.decision_id;
+                                    // Hover preview: enough of the message to
+                                    // resolve an uncertain call without
+                                    // leaving the accept flow
+                                    let preview = item
+                                        .body_preview
+                                        .clone()
+                                        .or_else(|| item.snippet.clone());
                                     html! {
                                         <div class="review-item-row" key={item.decision_id.to_string()}>
                                             <div class="review-item-main">
@@ -2946,6 +2953,20 @@ fn archive_review_panel() -> Html {
                                                 <span class="review-item-reason" title={item.reasoning.clone()}>
                                                     {&item.reasoning}
                                                 </span>
+                                                {if let Some(preview) = preview {
+                                                    html! {
+                                                        <div class="review-tooltip">
+                                                            <div class="review-tooltip-header">
+                                                                <span>{&item.from_address}</span>
+                                                                <span>{item.received_at.format("%Y-%m-%d %H:%M").to_string()}</span>
+                                                            </div>
+                                                            <div class="review-tooltip-subject">{&item.subject}</div>
+                                                            <div class="review-tooltip-body">{preview}</div>
+                                                        </div>
+                                                    }
+                                                } else {
+                                                    html! {}
+                                                }}
                                             </div>
                                             <span class="review-item-date">
                                                 {item.received_at.format("%Y-%m-%d").to_string()}

--- a/crates/frontend/styles.css
+++ b/crates/frontend/styles.css
@@ -2274,3 +2274,58 @@ main {
     font-size: 13px;
     margin-top: 12px;
 }
+
+/* Hover preview of the message body on review rows: appears after a short
+   delay, stays open while the pointer is over it (so long previews can be
+   scrolled), and sits above neighbouring rows */
+.review-item-main {
+    position: relative;
+}
+
+.review-tooltip {
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.15s ease 0.35s, visibility 0s linear 0.35s;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 40;
+    width: 620px;
+    max-width: 85vw;
+    max-height: 320px;
+    overflow-y: auto;
+    background-color: #fff;
+    border: 1px solid #d5dbdb;
+    border-radius: 8px;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+    padding: 12px 14px;
+}
+
+.review-item-main:hover .review-tooltip {
+    visibility: visible;
+    opacity: 1;
+}
+
+.review-tooltip-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 12px;
+    color: #7f8c8d;
+    margin-bottom: 4px;
+}
+
+.review-tooltip-subject {
+    font-weight: 600;
+    font-size: 13px;
+    margin-bottom: 8px;
+    color: #2c3e50;
+}
+
+.review-tooltip-body {
+    font-size: 13px;
+    line-height: 1.45;
+    color: #333;
+    white-space: pre-wrap;
+    word-break: break-word;
+}

--- a/crates/shared-types/src/lib.rs
+++ b/crates/shared-types/src/lib.rs
@@ -407,6 +407,8 @@ pub struct ArchiveReviewItem {
     pub from_name: Option<String>,
     pub received_at: DateTime<Utc>,
     pub snippet: Option<String>,
+    /// Leading portion of the plain-text body, for hover preview in review
+    pub body_preview: Option<String>,
 }
 
 /// Bulk view of archive determinations (dry-run audit surface)


### PR DESCRIPTION
For uncertain archive calls: hovering a row in the Review tab now reveals a tooltip (after a short delay, so rapid accepting isn't visually noisy) showing sender, date, subject, and the first ~1200 characters of the message body — snippet as fallback when no plain-text body exists. The tooltip stays open while hovered and scrolls, so longer previews are readable without leaving the accept flow.

Wire change: `ArchiveReviewItem` gains `body_preview: Option<String>`, populated server-side with char-boundary-safe truncation (500 items ship in one response, so full bodies stay out of the payload).