### PR TITLE
Receipt forwarding to Ramp and sender-grouped archive bundles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -177,6 +177,7 @@ cargo clippy --workspace --all-targets --locked # Lint code as CI does
 - Agents act ONLY through the `agent-cli` binary -> REST API (`POST /api/triage/decisions`); never give agents direct DB access
 - INVARIANT: ingestion is never gated on triage; Anthropic/API failures must never touch Gmail-sync health or backoff (separate failure domains)
 - Calendar writes are gated: agents propose `create_calendar_event` decisions; approval executes to the "Agent" calendar
+- Receipt forwarding is gated: screening proposes `forward_email` decisions for receipts; approval forwards the original as an RFC 822 attachment from the account it landed in (destination is server policy: `TRIAGE_FORWARD_TO`, default receipts@ramp.com — agents never choose destinations), then labels `agent-forwarded` and archives
 - Requires the `claude` binary plus a credential (DB-stored login token preferred, `ANTHROPIC_API_KEY` env fallback); otherwise mode=disabled and emails simply stay pending — there is no other classifier (the old keyword/rule system was removed 2026-08-04)
 - Do not change TriageDecideAction / PipelineStatsResponse wire shapes casually - agent-cli and monitoring depend on them
 

--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,8 @@ RUST_LOG=info
 # TRIAGE_SCREEN_MODEL=claude-haiku-4-5
 # TRIAGE_ARCHIVE_MODEL=claude-sonnet-4-5
 # TRIAGE_ACTION_MODEL=claude-opus-4-8
+# Where approved receipt forwards are sent (server policy, not agent-chosen)
+# TRIAGE_FORWARD_TO=receipts@ramp.com
 # TRIAGE_SESSION_TIMEOUT_SECS=600
 # Archive policy: "propose" (dry run, default) or "execute" (auto-archive)
 # TRIAGE_ARCHIVE_MODE=propose

--- a/crates/backend/src/bin/agent_cli.rs
+++ b/crates/backend/src/bin/agent_cli.rs
@@ -120,6 +120,14 @@ enum DecideCommands {
         #[arg(long)]
         reasoning: String,
     },
+    /// Propose forwarding (e.g. a receipt to the expense system); the
+    /// destination is server policy and the user approves before it sends
+    Forward {
+        #[arg(long)]
+        email_id: Uuid,
+        #[arg(long)]
+        reasoning: String,
+    },
 }
 
 fn resolve_token(cli_token: Option<String>) -> Result<String> {
@@ -203,6 +211,10 @@ async fn main() -> Result<()> {
                     email_id,
                     reasoning,
                 } => (email_id, TriageDecideAction::QueueAction, reasoning),
+                DecideCommands::Forward {
+                    email_id,
+                    reasoning,
+                } => (email_id, TriageDecideAction::Forward, reasoning),
                 DecideCommands::Event {
                     email_id,
                     summary,

--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -664,6 +664,12 @@ async fn execute_approved_side_effect(
                 .map_err(ApiError::Internal)?;
             Ok(true)
         }
+        "forward_email" => {
+            crate::services::TriageService::execute_forward_decision(&state.pool, decision_id)
+                .await
+                .map_err(ApiError::Internal)?;
+            Ok(true)
+        }
         _ => Ok(false),
     }
 }

--- a/crates/backend/src/pollers/gmail_client.rs
+++ b/crates/backend/src/pollers/gmail_client.rs
@@ -214,6 +214,74 @@ impl GmailClient {
         Ok(Self::parse_message(message))
     }
 
+    /// Forward a message as an RFC 822 attachment from this account. Gmail
+    /// has no forward endpoint, so this fetches the original raw message and
+    /// sends a new one carrying it whole — headers, body, and attachments
+    /// survive intact, which is what expense-ingestion inboxes parse.
+    pub async fn forward_as_attachment(
+        &self,
+        message_id: &str,
+        to_address: &str,
+        from_address: &str,
+        original_subject: &str,
+    ) -> Result<()> {
+        let (_, original) = self
+            .hub
+            .users()
+            .messages_get("me", message_id)
+            .format("raw")
+            .doit()
+            .await
+            .context("Failed to fetch raw message for forwarding")?;
+        let raw = original
+            .raw
+            .context("Gmail returned no raw payload for message")?;
+
+        // Header values must not smuggle CRLFs into the envelope
+        let subject: String = original_subject
+            .chars()
+            .filter(|c| *c != '\r' && *c != '\n')
+            .collect();
+
+        let boundary = format!("fwd-{message_id}");
+        let mut mime: Vec<u8> = Vec::with_capacity(raw.len() + 512);
+        mime.extend_from_slice(
+            format!(
+                "From: {from_address}\r\n\
+                 To: {to_address}\r\n\
+                 Subject: Fwd: {subject}\r\n\
+                 MIME-Version: 1.0\r\n\
+                 Content-Type: multipart/mixed; boundary=\"{boundary}\"\r\n\
+                 \r\n\
+                 --{boundary}\r\n\
+                 Content-Type: text/plain; charset=utf-8\r\n\
+                 \r\n\
+                 Forwarded receipt.\r\n\
+                 \r\n\
+                 --{boundary}\r\n\
+                 Content-Type: message/rfc822\r\n\
+                 Content-Disposition: attachment; filename=\"original.eml\"\r\n\
+                 \r\n"
+            )
+            .as_bytes(),
+        );
+        mime.extend_from_slice(&raw);
+        mime.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+
+        self.hub
+            .users()
+            .messages_send(google_gmail1::api::Message::default(), "me")
+            .upload(
+                std::io::Cursor::new(mime),
+                "message/rfc822".parse().expect("static mime type"),
+            )
+            .await
+            .context("Failed to send forwarded message")?;
+
+        tracing::info!("Forwarded message {} to {}", message_id, to_address);
+        Ok(())
+    }
+
     /// Archive a message (remove INBOX label)
     #[allow(dead_code)]
     pub async fn archive_message(&self, message_id: &str) -> Result<()> {

--- a/crates/backend/src/pollers/triage.rs
+++ b/crates/backend/src/pollers/triage.rs
@@ -101,6 +101,13 @@ For EVERY email in the file, make exactly one disposition by running the
 agent-cli command via Bash. Do not skip any email. Do not take any other action.
 
 Dispositions:
+- Purchase receipt, paid invoice, or order confirmation showing an amount the
+  user paid (business or personal spend the expense system should capture):
+  agent-cli decide forward --email-id <id> --reasoning "<why>"
+  This proposes forwarding it to the user's expense inbox; the user approves
+  before anything sends. Check this BEFORE the archive-candidate rule —
+  receipts look like automated mail but must not be lost to the archive.
+  Not receipts: payment reminders, unpaid invoices, marketing about spending.
 - Newsletter, promotion, notification, or automated mail with no action needed:
   agent-cli decide archive-candidate --email-id <id> --reasoning "<why>"
 - Contains a real-world event with a concrete date/time the user could attend

--- a/crates/backend/src/services/triage.rs
+++ b/crates/backend/src/services/triage.rs
@@ -11,8 +11,8 @@ use uuid::Uuid;
 use crate::db::{self, DbPool};
 use crate::pollers::gmail_client::GmailClient;
 use shared_types::{
-    DecisionStatus, DecisionType, ProposedCalendarEventAction, ProposedTodoAction,
-    TriageDecideAction, TriageDecideRequest, TriageDecideResponse,
+    DecisionStatus, DecisionType, ProposedCalendarEventAction, ProposedForwardAction,
+    ProposedTodoAction, TriageDecideAction, TriageDecideRequest, TriageDecideResponse,
 };
 
 /// Gmail label applied to everything the agent archives
@@ -20,6 +20,15 @@ pub const AGENT_ARCHIVE_LABEL: &str = "agent-archived";
 
 /// Default calendar for agent-created events
 pub const AGENT_CALENDAR_NAME: &str = "Agent";
+
+/// Gmail label applied to everything the agent forwards
+pub const AGENT_FORWARD_LABEL: &str = "agent-forwarded";
+
+/// Where forward proposals are addressed (e.g. the Ramp receipts inbox).
+/// Server policy: agents propose THAT an email be forwarded, never where to.
+pub fn forward_to_address() -> String {
+    std::env::var("TRIAGE_FORWARD_TO").unwrap_or_else(|_| "receipts@ramp.com".to_string())
+}
 
 /// Archive execution policy. "propose" (the default) records Sonnet's
 /// determinations as gated proposals with full fidelity but never touches
@@ -105,6 +114,41 @@ impl TriageService {
                     email_id: email.id,
                     decision_id: None,
                     triage_status: "action_queued".to_string(),
+                    executed: false,
+                })
+            }
+
+            TriageDecideAction::Forward => {
+                // Always gated: sending mail is outward-facing. Approval
+                // forwards from the account the email landed in, then labels
+                // and archives it (a forwarded receipt is a handled receipt).
+                let account = db::google_accounts::get_by_id(&mut conn, email.account_id)
+                    .await
+                    .context("Account for email not found")?;
+                let action = ProposedForwardAction {
+                    to_address: forward_to_address(),
+                    from_account: account.email.clone(),
+                    subject: email.subject.clone(),
+                };
+                let decision_id = db::decisions::create_with_status(
+                    &mut conn,
+                    "email",
+                    Some(email.id),
+                    Some(&email.gmail_id),
+                    DecisionType::ForwardEmail.as_str(),
+                    &serde_json::to_string(&action)?,
+                    &req.reasoning,
+                    reasoning_details.as_deref(),
+                    0.9,
+                    DecisionStatus::Proposed.as_str(),
+                )
+                .await?;
+                db::emails::set_triage_status(&mut conn, email.id, "forward_proposed").await?;
+                db::emails::mark_processed(&mut conn, email.id).await?;
+                Ok(TriageDecideResponse {
+                    email_id: email.id,
+                    decision_id: Some(decision_id),
+                    triage_status: "forward_proposed".to_string(),
                     executed: false,
                 })
             }
@@ -292,6 +336,46 @@ impl TriageService {
         let mut conn = pool.get().await.context("Failed to get DB connection")?;
         db::emails::mark_archived_in_gmail(&mut conn, email.id).await?;
         db::emails::set_triage_status(&mut conn, email.id, "archived").await?;
+        db::decisions::mark_executed(&mut conn, decision_id).await?;
+
+        Ok(())
+    }
+
+    /// Execute an approved forward decision: send the original message as an
+    /// RFC 822 attachment from the account it landed in, then label it
+    /// agent-forwarded and archive it — a forwarded receipt is handled.
+    pub async fn execute_forward_decision(pool: &DbPool, decision_id: Uuid) -> Result<()> {
+        let mut conn = pool.get().await.context("Failed to get DB connection")?;
+
+        let decision = db::decisions::get_by_id(&mut conn, decision_id)
+            .await
+            .context("Decision not found")?;
+        let action: ProposedForwardAction = serde_json::from_str(&decision.proposed_action)
+            .context("Forward decision has malformed proposed_action")?;
+        let email_id = decision
+            .source_id
+            .context("Forward decision has no source email")?;
+        let email = db::emails::get_by_id(&mut conn, email_id).await?;
+        let account = db::google_accounts::get_by_id(&mut conn, email.account_id).await?;
+        drop(conn);
+
+        let client = GmailClient::from_account(&account).await?;
+        client
+            .forward_as_attachment(
+                &email.gmail_id,
+                &action.to_address,
+                &account.email,
+                &email.subject,
+            )
+            .await?;
+        let label_id = client.ensure_label(AGENT_FORWARD_LABEL).await?;
+        client
+            .archive_with_label(&email.gmail_id, &label_id)
+            .await?;
+
+        let mut conn = pool.get().await.context("Failed to get DB connection")?;
+        db::emails::mark_archived_in_gmail(&mut conn, email.id).await?;
+        db::emails::set_triage_status(&mut conn, email.id, "forwarded").await?;
         db::decisions::mark_executed(&mut conn, decision_id).await?;
 
         Ok(())

--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -5,8 +5,8 @@ use shared_types::{
     BatchRejectDecisionsRequest, CalendarEventResponse, Category, ChatMessageResponse,
     ChatResponse, ClaudeAuthStatusResponse, CreateTodoRequest, DecisionStats, EmailResponse,
     GoogleAccountResponse, LoginInitResponse, PipelineStatsResponse, ProposedCalendarEventAction,
-    ProposedTodoAction, RejectDecisionRequest, SendChatMessageRequest, SuggestedAction, Todo,
-    UpdateAboutMeRequest, UpdateTodoRequest,
+    ProposedForwardAction, ProposedTodoAction, RejectDecisionRequest, SendChatMessageRequest,
+    SuggestedAction, Todo, UpdateAboutMeRequest, UpdateTodoRequest,
 };
 use uuid::Uuid;
 use web_sys::{Element, HtmlInputElement};
@@ -1071,6 +1071,12 @@ fn decision_detail_view(props: &DecisionDetailProps) -> Html {
         } else {
             None
         };
+    let proposed_forward: Option<ProposedForwardAction> =
+        if decision.decision_type == "forward_email" {
+            serde_json::from_value(decision.proposed_action.clone()).ok()
+        } else {
+            None
+        };
 
     html! {
         <div class="decision-detail">
@@ -1118,6 +1124,20 @@ fn decision_detail_view(props: &DecisionDetailProps) -> Html {
                             html! {}
                         }}
                         <p class="gate-note">{"Approving creates this event on your Agent calendar."}</p>
+                    </div>
+                }
+            } else {
+                html! {}
+            }}
+
+            {if let Some(fwd) = proposed_forward {
+                html! {
+                    <div class="detail-section">
+                        <h4>{"Proposed Forward"}</h4>
+                        <p><strong>{"Subject: "}</strong>{&fwd.subject}</p>
+                        <p><strong>{"From account: "}</strong>{&fwd.from_account}</p>
+                        <p><strong>{"To: "}</strong>{&fwd.to_address}</p>
+                        <p class="gate-note">{"Approving forwards the original email (with attachments) to this address, then labels it agent-forwarded and archives it."}</p>
                     </div>
                 }
             } else {
@@ -2606,10 +2626,56 @@ const RETURNED_BUNDLE_COOLDOWN_MS: u32 = 4_000;
 struct ReviewBundle {
     key: usize,
     items: Vec<ArchiveReviewItem>,
+    /// Sender shared by every item, when the bundle is a per-sender group —
+    /// scanning one name clears the whole category
+    sender: Option<String>,
     /// Came back after a failed accept
     returned: bool,
     /// Server error from the failed accept, shown on the card
     error: Option<String>,
+}
+
+/// Group proposals by sender: senders with multiple proposals get their own
+/// bundle (largest first — one click clears a whole newsletter), and
+/// one-off senders pool into assorted bundles of [`REVIEW_BUNDLE_SIZE`].
+fn bundle_by_sender(items: Vec<ArchiveReviewItem>) -> Vec<ReviewBundle> {
+    let mut by_sender: std::collections::HashMap<String, Vec<ArchiveReviewItem>> =
+        std::collections::HashMap::new();
+    for item in items {
+        by_sender
+            .entry(item.from_address.clone())
+            .or_default()
+            .push(item);
+    }
+
+    let mut groups: Vec<(String, Vec<ArchiveReviewItem>)> = by_sender.into_iter().collect();
+    groups.sort_by(|a, b| b.1.len().cmp(&a.1.len()).then_with(|| a.0.cmp(&b.0)));
+
+    let mut bundles = Vec::new();
+    let mut singles: Vec<ArchiveReviewItem> = Vec::new();
+    for (sender, group) in groups {
+        if group.len() == 1 {
+            singles.extend(group);
+        } else {
+            bundles.push(ReviewBundle {
+                key: next_bundle_key(),
+                items: group,
+                sender: Some(sender),
+                returned: false,
+                error: None,
+            });
+        }
+    }
+    for chunk in singles.chunks(REVIEW_BUNDLE_SIZE) {
+        bundles.push(ReviewBundle {
+            key: next_bundle_key(),
+            items: chunk.to_vec(),
+            sender: None,
+            returned: false,
+            error: None,
+        });
+    }
+    bundles
 }
 
 #[derive(PartialEq, Default)]
@@ -2682,9 +2748,14 @@ impl Reducible for ReviewQueue {
                     "{} email(s) couldn't be archived - returned to the back of the queue",
                     items.len()
                 ));
+                let sender = items
+                    .first()
+                    .map(|i| i.from_address.clone())
+                    .filter(|s| items.iter().all(|i| &i.from_address == s));
                 next.bundles.push(ReviewBundle {
                     key,
                     items,
+                    sender,
                     returned: true,
                     error: Some(error),
                 });
@@ -2728,19 +2799,9 @@ fn archive_review_panel() -> Html {
                 match Request::get("/api/pipeline/archive-review").send().await {
                     Ok(resp) if resp.ok() => match resp.json::<ArchiveReviewResponse>().await {
                         Ok(data) => {
-                            let bundles = data
-                                .items
-                                .chunks(REVIEW_BUNDLE_SIZE)
-                                .map(|chunk| ReviewBundle {
-                                    key: next_bundle_key(),
-                                    items: chunk.to_vec(),
-                                    returned: false,
-                                    error: None,
-                                })
-                                .collect();
                             queue.dispatch(ReviewMsg::Loaded {
                                 mode: data.archive_mode,
-                                bundles,
+                                bundles: bundle_by_sender(data.items),
                             });
                         }
                         Err(e) => {
@@ -2917,6 +2978,19 @@ fn archive_review_panel() -> Html {
                                 </span>
                             </div>
                             <div class={if bundle.returned { "review-bundle-card bundle-returned" } else { "review-bundle-card" }}>
+                                <div class="bundle-sender-header">
+                                    {match &bundle.sender {
+                                        Some(s) => html! {
+                                            <>
+                                                <span class="bundle-sender-name">{s}</span>
+                                                <span class="bundle-sender-count">{format!("{} emails from this sender", bundle.items.len())}</span>
+                                            </>
+                                        },
+                                        None => html! {
+                                            <span class="bundle-sender-count">{format!("{} assorted senders", bundle.items.len())}</span>
+                                        },
+                                    }}
+                                </div>
                                 {if let Some(err) = bundle.error.clone() {
                                     html! {
                                         <div class="bundle-error-note">
@@ -3030,6 +3104,8 @@ fn pipeline_view() -> Html {
         ("archive_candidate", "Awaiting archive determination"),
         ("archived", "Archived by agent"),
         ("event_proposed", "Calendar events proposed"),
+        ("forward_proposed", "Forwards proposed"),
+        ("forwarded", "Forwarded"),
         ("action_queued", "Queued for action pass"),
         ("todo_proposed", "Todos proposed"),
         ("kept", "Kept in inbox"),

--- a/crates/frontend/styles.css
+++ b/crates/frontend/styles.css
@@ -2329,3 +2329,24 @@ main {
     white-space: pre-wrap;
     word-break: break-word;
 }
+
+/* Sender-group header on review bundles: the category label you scan
+   before hitting accept */
+.bundle-sender-header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    padding: 10px 0 6px;
+    border-bottom: 2px solid #ecf0f1;
+}
+
+.bundle-sender-name {
+    font-weight: 700;
+    font-size: 15px;
+    color: #2c3e50;
+}
+
+.bundle-sender-count {
+    font-size: 12px;
+    color: #7f8c8d;
+}

--- a/crates/shared-types/src/lib.rs
+++ b/crates/shared-types/src/lib.rs
@@ -302,6 +302,16 @@ pub struct CreateCalendarEventResponse {
 }
 
 /// Calendar event proposed by the triage agent (stored as a gated decision's
+/// The action payload of a forward_email decision (stored as JSON in
+/// proposed_action; executed on approval). The destination comes from server
+/// config, never from the agent.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProposedForwardAction {
+    pub to_address: String,
+    pub from_account: String,
+    pub subject: String,
+}
+
 /// proposed_action; executed on approval)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProposedCalendarEventAction {
@@ -344,6 +354,9 @@ pub enum TriageDecideAction {
     Ignore,
     /// Send to the action queue for the deeper (Opus) pass
     QueueAction,
+    /// Propose forwarding this email (e.g. a receipt to the expense system).
+    /// The destination is server policy, never agent-chosen.
+    Forward,
 }
 
 /// Request body for POST /api/triage/decisions (sent by agent-cli)
@@ -483,6 +496,7 @@ pub enum DecisionType {
     Categorize,
     SetDueDate,
     CreateCalendarEvent,
+    ForwardEmail,
 }
 
 impl DecisionType {
@@ -495,6 +509,7 @@ impl DecisionType {
             DecisionType::Categorize => "categorize",
             DecisionType::SetDueDate => "set_due_date",
             DecisionType::CreateCalendarEvent => "create_calendar_event",
+            DecisionType::ForwardEmail => "forward_email",
         }
     }
 
@@ -507,6 +522,7 @@ impl DecisionType {
             "categorize" => Some(DecisionType::Categorize),
             "set_due_date" => Some(DecisionType::SetDueDate),
             "create_calendar_event" => Some(DecisionType::CreateCalendarEvent),
+            "forward_email" => Some(DecisionType::ForwardEmail),
             _ => None,
         }
     }
@@ -886,6 +902,26 @@ mod triage_type_tests {
         )
         .unwrap();
         assert!(matches!(parsed, TriageDecideAction::Todo { .. }));
+
+        let json = serde_json::to_value(&TriageDecideAction::Forward).unwrap();
+        assert_eq!(json["type"], "forward");
+    }
+
+    #[test]
+    fn forward_decision_type_round_trips() {
+        assert_eq!(DecisionType::ForwardEmail.as_str(), "forward_email");
+        assert_eq!(
+            DecisionType::parse("forward_email"),
+            Some(DecisionType::ForwardEmail)
+        );
+        let action = ProposedForwardAction {
+            to_address: "receipts@ramp.com".to_string(),
+            from_account: "user@example.com".to_string(),
+            subject: "Your receipt".to_string(),
+        };
+        let parsed: ProposedForwardAction =
+            serde_json::from_str(&serde_json::to_string(&action).unwrap()).unwrap();
+        assert_eq!(parsed, action);
     }
 
     #[test]
@@ -975,6 +1011,8 @@ mod serde_roundtrip_tests {
             DecisionType::Defer,
             DecisionType::Categorize,
             DecisionType::SetDueDate,
+            DecisionType::CreateCalendarEvent,
+            DecisionType::ForwardEmail,
         ] {
             assert_eq!(roundtrip(&value), value);
             assert_eq!(DecisionType::parse(value.as_str()), Some(value.clone()));


### PR DESCRIPTION
Two features:

**Receipt forwarding (gated).** The screening stage gets a new disposition: purchase receipts, paid invoices, and order confirmations become `forward_email` proposals — checked *before* the archive-candidate rule so receipts aren't swallowed by bulk-mail archiving. Key properties:

- **Destination is server policy**: `TRIAGE_FORWARD_TO` (default `receipts@ramp.com`). Agents propose *that* an email should be forwarded, never *where* — an agent can't exfiltrate mail to arbitrary addresses.
- **Always gated**: sending mail is outward-facing, so every forward lands in the decision inbox for approval regardless of archive mode.
- **Execution**: Gmail has no forward endpoint, so approval fetches the original raw RFC 822 message and sends it as a `message/rfc822` attachment from the account it landed in — headers, body, and attachments survive intact (what Ramp's parser wants, and sender-matching works because it comes from your own account). Then labels `agent-forwarded` and archives: a forwarded receipt is a handled receipt. Sending uses the already-granted `gmail.modify` scope; no re-consent.
- Decision inbox renders the proposal with subject, source account, destination, and what approval will do.

**Sender-grouped review bundles.** Archive bundles are now grouped by sender — largest groups first, so one glance at the header ("newsletter@x.com — 14 emails") covers a category and one click clears it. One-off senders pool into assorted bundles of 10. Failed accepts keep their sender label when they return to the queue.

Wire additions (additive; both sides ship together): `TriageDecideAction::Forward`, `DecisionType::ForwardEmail`, `ProposedForwardAction`, plus roundtrip pins and pipeline-stage rows for `forward_proposed`/`forwarded`.