### PR TITLE
Keep executed archive decisions out of the review queue

### DIFF
--- a/crates/backend/src/db.rs
+++ b/crates/backend/src/db.rs
@@ -706,8 +706,10 @@ pub mod decisions {
         Ok(rows.into_iter().map(Into::into).collect())
     }
 
-    /// List decisions of one type, newest first
-    pub async fn list_by_type(
+    /// List still-proposed decisions of one type, newest first. The review
+    /// queue feeds off this: already approved/executed/rejected decisions
+    /// must not reappear as acceptable work.
+    pub async fn list_proposed_by_type(
         conn: &mut AsyncPgConnection,
         decision_type_val: &str,
         limit: i64,
@@ -716,6 +718,7 @@ pub mod decisions {
 
         let rows = agent_decisions
             .filter(decision_type.eq(decision_type_val))
+            .filter(status.eq(DecisionStatus::Proposed.as_str()))
             .order_by(created_at.desc())
             .limit(limit)
             .load::<AgentDecisionRow>(conn)

--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -514,7 +514,7 @@ pub async fn get_archive_review(
 ) -> ApiResult<Json<ArchiveReviewResponse>> {
     let mut conn = get_conn(&state.pool).await?;
 
-    let decisions_list = decisions::list_by_type(&mut conn, "archive", 500).await?;
+    let decisions_list = decisions::list_proposed_by_type(&mut conn, "archive", 500).await?;
     let email_ids: Vec<Uuid> = decisions_list.iter().filter_map(|d| d.source_id).collect();
     let emails_list = emails::list_by_ids(&mut conn, &email_ids).await?;
     let accounts = google_accounts::list_all(&mut conn).await?;

--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -2790,6 +2790,9 @@ impl Reducible for ReviewQueue {
 #[function_component(ArchiveReviewPanel)]
 fn archive_review_panel() -> Html {
     let queue = use_reducer(ReviewQueue::default);
+    // Accepts/keeps here resolve pending decisions; the nav badge and the
+    // decision inbox count must learn about it
+    let refresh_pending = use_app_context().refresh_pending_count;
 
     let load = {
         let queue = queue.clone();
@@ -2828,6 +2831,7 @@ fn archive_review_panel() -> Html {
 
     let on_accept = {
         let queue = queue.clone();
+        let refresh_pending = refresh_pending.clone();
         Callback::from(move |_| {
             let Some(front) = queue.bundles.first() else {
                 return;
@@ -2841,6 +2845,7 @@ fn archive_review_panel() -> Html {
             // so the next bundle is already under the cursor
             queue.dispatch(ReviewMsg::PopFront);
             let queue = queue.clone();
+            let refresh_pending = refresh_pending.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 let request = BatchApproveDecisionsRequest { decision_ids: ids };
                 let outcome = match Request::post("/api/decisions/batch/approve")
@@ -2892,18 +2897,21 @@ fn archive_review_panel() -> Html {
                     })
                     .forget();
                 }
+                refresh_pending.emit(());
             });
         })
     };
 
     let on_keep = {
         let queue = queue.clone();
+        let refresh_pending = refresh_pending.clone();
         Callback::from(move |(bundle_key, decision_id): (usize, Uuid)| {
             queue.dispatch(ReviewMsg::RemoveItem {
                 bundle_key,
                 decision_id,
             });
             let queue = queue.clone();
+            let refresh_pending = refresh_pending.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 let request = BatchRejectDecisionsRequest {
                     decision_ids: vec![decision_id],
@@ -2925,6 +2933,7 @@ fn archive_review_panel() -> Html {
                             .to_string(),
                     )));
                 }
+                refresh_pending.emit(());
             });
         })
     };


### PR DESCRIPTION
Fixes the "already-archived emails still show up" report, which was two bugs:

- **The review endpoint had no status filter** — `list_by_type("archive", 500)` returned every archive decision regardless of status, so executed/approved/rejected ones reappeared as acceptable bundles after any refresh, and re-accepting them could only fail and bounce. The query is now proposed-only.
- **The pending-decisions nav badge went stale** — accepts and keeps in the Review tab never triggered a recount. They do now.