### PR TITLE
Standardized unsubscribe on sender-grouped review bundles

### DIFF
--- a/crates/backend/src/handlers.rs
+++ b/crates/backend/src/handlers.rs
@@ -193,6 +193,17 @@ pub async fn get_email(
     }))
 }
 
+/// Attempt a standardized unsubscribe for the sender of this email
+pub async fn unsubscribe_email(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> ApiResult<Json<shared_types::UnsubscribeResponse>> {
+    let resp = crate::services::UnsubscribeService::unsubscribe(&state.pool, id)
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(Json(resp))
+}
+
 #[derive(Debug, Serialize)]
 pub struct EmailStatsResponse {
     pub total: i64,

--- a/crates/backend/src/main.rs
+++ b/crates/backend/src/main.rs
@@ -79,6 +79,7 @@ pub fn build_app(state: AppState, config: &Config) -> Router {
         .route("/emails", get(handlers::list_emails))
         .route("/emails/stats", get(handlers::get_email_stats))
         .route("/emails/:id", get(handlers::get_email))
+        .route("/emails/:id/unsubscribe", post(handlers::unsubscribe_email))
         // Agent decision routes
         .route("/decisions", get(handlers::list_decisions))
         .route("/decisions", post(handlers::create_decision))

--- a/crates/backend/src/pollers/gmail_client.rs
+++ b/crates/backend/src/pollers/gmail_client.rs
@@ -214,6 +214,73 @@ impl GmailClient {
         Ok(Self::parse_message(message))
     }
 
+    /// Fetch the List-Unsubscribe / List-Unsubscribe-Post headers for a
+    /// message (metadata-only fetch — cheap, works for any stored email
+    /// without schema support)
+    pub async fn get_unsubscribe_headers(
+        &self,
+        message_id: &str,
+    ) -> Result<(Option<String>, Option<String>)> {
+        let (_, message) = self
+            .hub
+            .users()
+            .messages_get("me", message_id)
+            .format("metadata")
+            .add_metadata_headers("List-Unsubscribe")
+            .add_metadata_headers("List-Unsubscribe-Post")
+            .doit()
+            .await
+            .context("Failed to fetch unsubscribe headers")?;
+
+        let mut list_unsubscribe = None;
+        let mut list_unsubscribe_post = None;
+        if let Some(headers) = message.payload.and_then(|p| p.headers) {
+            for h in headers {
+                match h.name.as_deref() {
+                    Some(n) if n.eq_ignore_ascii_case("List-Unsubscribe") => {
+                        list_unsubscribe = h.value;
+                    }
+                    Some(n) if n.eq_ignore_ascii_case("List-Unsubscribe-Post") => {
+                        list_unsubscribe_post = h.value;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok((list_unsubscribe, list_unsubscribe_post))
+    }
+
+    /// Send a bare plain-text message from this account (mailto-style
+    /// unsubscribe requests)
+    pub async fn send_plain_message(
+        &self,
+        to_address: &str,
+        from_address: &str,
+        subject: &str,
+        body: &str,
+    ) -> Result<()> {
+        let clean =
+            |s: &str| -> String { s.chars().filter(|c| *c != '\r' && *c != '\n').collect() };
+        let mime = format!(
+            "From: {}\r\nTo: {}\r\nSubject: {}\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n{}\r\n",
+            clean(from_address),
+            clean(to_address),
+            clean(subject),
+            body
+        );
+
+        self.hub
+            .users()
+            .messages_send(google_gmail1::api::Message::default(), "me")
+            .upload(
+                std::io::Cursor::new(mime.into_bytes()),
+                "message/rfc822".parse().expect("static mime type"),
+            )
+            .await
+            .context("Failed to send message")?;
+        Ok(())
+    }
+
     /// Forward a message as an RFC 822 attachment from this account. Gmail
     /// has no forward endpoint, so this fetches the original raw message and
     /// sends a new one carrying it whole — headers, body, and attachments

--- a/crates/backend/src/services/mod.rs
+++ b/crates/backend/src/services/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod decision;
 pub mod triage;
+pub mod unsubscribe;
 
 pub use decision::DecisionService;
 pub use triage::TriageService;
+pub use unsubscribe::UnsubscribeService;

--- a/crates/backend/src/services/unsubscribe.rs
+++ b/crates/backend/src/services/unsubscribe.rs
@@ -1,0 +1,179 @@
+//! Standardized unsubscribe (RFC 2369 List-Unsubscribe, RFC 8058 one-click).
+//!
+//! Headers are fetched live from Gmail per attempt, so this works for every
+//! stored email with no schema support. Preference order: one-click HTTPS
+//! POST (built for automation) > mailto (sent from the owning account) >
+//! plain HTTPS link (returned for a human to open). Anything else is "none".
+
+use anyhow::{Context, Result};
+use shared_types::UnsubscribeResponse;
+use uuid::Uuid;
+
+use crate::db::{self, DbPool};
+use crate::pollers::gmail_client::GmailClient;
+
+/// Entries inside a List-Unsubscribe header: `<mailto:...>, <https://...>`
+fn parse_entries(header: &str) -> Vec<String> {
+    header
+        .split(',')
+        .filter_map(|part| {
+            let part = part.trim();
+            let start = part.find('<')? + 1;
+            let end = part.find('>')?;
+            (start < end).then(|| part[start..end].trim().to_string())
+        })
+        .collect()
+}
+
+fn https_entry(entries: &[String]) -> Option<&String> {
+    entries.iter().find(|e| e.starts_with("https://"))
+}
+
+fn mailto_entry(entries: &[String]) -> Option<&String> {
+    entries.iter().find(|e| e.starts_with("mailto:"))
+}
+
+/// RFC 8058: the header must contain exactly `List-Unsubscribe=One-Click`
+fn is_one_click(post_header: Option<&str>) -> bool {
+    post_header
+        .map(|v| v.trim().eq_ignore_ascii_case("List-Unsubscribe=One-Click"))
+        .unwrap_or(false)
+}
+
+/// Refuse obviously non-public targets before the server POSTs anywhere
+/// (light SSRF guard: https only, named host, no userinfo, no port games)
+fn url_is_sane(url: &str) -> bool {
+    let Some(rest) = url.strip_prefix("https://") else {
+        return false;
+    };
+    let host = rest.split(['/', '?', '#']).next().unwrap_or("");
+    !host.is_empty()
+        && !host.contains('@')
+        && !host.contains(':')
+        && host.contains('.')
+        && !host.chars().all(|c| c.is_ascii_digit() || c == '.')
+}
+
+pub struct UnsubscribeService;
+
+impl UnsubscribeService {
+    pub async fn unsubscribe(pool: &DbPool, email_id: Uuid) -> Result<UnsubscribeResponse> {
+        let mut conn = pool.get().await.context("Failed to get DB connection")?;
+        let email = db::emails::get_by_id(&mut conn, email_id)
+            .await
+            .context("Email not found")?;
+        let account = db::google_accounts::get_by_id(&mut conn, email.account_id).await?;
+        drop(conn);
+
+        let client = GmailClient::from_account(&account).await?;
+        let (list_unsub, list_unsub_post) = client.get_unsubscribe_headers(&email.gmail_id).await?;
+
+        let Some(header) = list_unsub else {
+            return Ok(UnsubscribeResponse {
+                method: "none".to_string(),
+                url: None,
+            });
+        };
+        let entries = parse_entries(&header);
+
+        // One-click: a plain POST with the fixed form body completes the
+        // unsubscribe with no human involved — that is its entire contract
+        if is_one_click(list_unsub_post.as_deref()) {
+            if let Some(url) = https_entry(&entries).filter(|u| url_is_sane(u)) {
+                let resp = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(15))
+                    .build()?
+                    .post(url)
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body("List-Unsubscribe=One-Click")
+                    .send()
+                    .await
+                    .context("One-click unsubscribe POST failed")?;
+                if resp.status().is_success() || resp.status().is_redirection() {
+                    tracing::info!(
+                        "One-click unsubscribed {} from {}",
+                        account.email,
+                        email.from_address
+                    );
+                    return Ok(UnsubscribeResponse {
+                        method: "one_click".to_string(),
+                        url: None,
+                    });
+                }
+                tracing::warn!(
+                    "One-click unsubscribe returned {} for {}; falling back",
+                    resp.status(),
+                    email.from_address
+                );
+            }
+        }
+
+        // Mailto: send the request from the account the mail landed in
+        if let Some(mailto) = mailto_entry(&entries) {
+            let rest = &mailto["mailto:".len()..];
+            let (to, query) = rest.split_once('?').unwrap_or((rest, ""));
+            let subject = query
+                .split('&')
+                .find_map(|kv| kv.strip_prefix("subject="))
+                .map(|s| s.replace('+', " "))
+                .unwrap_or_else(|| "unsubscribe".to_string());
+            client
+                .send_plain_message(to, &account.email, &subject, "unsubscribe")
+                .await
+                .context("Unsubscribe mail failed to send")?;
+            tracing::info!("Sent unsubscribe mail for {} to {}", email.from_address, to);
+            return Ok(UnsubscribeResponse {
+                method: "mailto".to_string(),
+                url: None,
+            });
+        }
+
+        // A page that needs a human: hand the link back
+        if let Some(url) = https_entry(&entries) {
+            return Ok(UnsubscribeResponse {
+                method: "link".to_string(),
+                url: Some(url.clone()),
+            });
+        }
+
+        Ok(UnsubscribeResponse {
+            method: "none".to_string(),
+            url: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_multi_entry_headers() {
+        let entries = parse_entries(
+            "<mailto:unsub@lists.example.com?subject=stop>, <https://example.com/u/1>",
+        );
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0], "mailto:unsub@lists.example.com?subject=stop");
+        assert_eq!(entries[1], "https://example.com/u/1");
+        assert_eq!(mailto_entry(&entries), Some(&entries[0]));
+        assert_eq!(https_entry(&entries), Some(&entries[1]));
+    }
+
+    #[test]
+    fn one_click_requires_exact_token() {
+        assert!(is_one_click(Some("List-Unsubscribe=One-Click")));
+        assert!(is_one_click(Some(" list-unsubscribe=one-click ")));
+        assert!(!is_one_click(Some("something-else")));
+        assert!(!is_one_click(None));
+    }
+
+    #[test]
+    fn url_sanity_rejects_non_public_shapes() {
+        assert!(url_is_sane("https://example.com/unsub?u=1"));
+        assert!(!url_is_sane("http://example.com/unsub"));
+        assert!(!url_is_sane("https://10.0.0.1/unsub"));
+        assert!(!url_is_sane("https://evil.com:8080/unsub"));
+        assert!(!url_is_sane("https://user@evil.com/unsub"));
+        assert!(!url_is_sane("https://localhost/unsub"));
+    }
+}

--- a/crates/frontend/src/main.rs
+++ b/crates/frontend/src/main.rs
@@ -2683,6 +2683,8 @@ struct ReviewQueue {
     bundles: Vec<ReviewBundle>,
     /// Bundle keys whose buttons are in the post-failure cooldown
     disabled: std::collections::HashSet<usize>,
+    /// Unsubscribe progress/outcome per bundle key ("..." while in flight)
+    unsub: std::collections::HashMap<usize, String>,
     archive_mode: String,
     loaded: bool,
     banner: Option<String>,
@@ -2712,6 +2714,11 @@ enum ReviewMsg {
     /// Drop a permanently-failing returned bundle without a backend call
     DismissBundle(usize),
     Banner(Option<String>),
+    /// Unsubscribe progress/outcome for a sender bundle
+    UnsubStatus {
+        key: usize,
+        label: String,
+    },
 }
 
 impl Reducible for ReviewQueue {
@@ -2721,6 +2728,7 @@ impl Reducible for ReviewQueue {
         let mut next = ReviewQueue {
             bundles: self.bundles.clone(),
             disabled: self.disabled.clone(),
+            unsub: self.unsub.clone(),
             archive_mode: self.archive_mode.clone(),
             loaded: self.loaded,
             banner: self.banner.clone(),
@@ -2779,6 +2787,9 @@ impl Reducible for ReviewQueue {
                 next.disabled.remove(&key);
             }
             ReviewMsg::Banner(b) => next.banner = b,
+            ReviewMsg::UnsubStatus { key, label } => {
+                next.unsub.insert(key, label);
+            }
         }
         next.into()
     }
@@ -2938,6 +2949,47 @@ fn archive_review_panel() -> Html {
         })
     };
 
+    let on_unsubscribe = {
+        let queue = queue.clone();
+        Callback::from(move |(bundle_key, email_id): (usize, Uuid)| {
+            queue.dispatch(ReviewMsg::UnsubStatus {
+                key: bundle_key,
+                label: "...".to_string(),
+            });
+            let queue = queue.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let label = match Request::post(&format!("/api/emails/{email_id}/unsubscribe"))
+                    .send()
+                    .await
+                {
+                    Ok(resp) if resp.ok() => {
+                        match resp.json::<shared_types::UnsubscribeResponse>().await {
+                            Ok(out) => match out.method.as_str() {
+                                "one_click" => "Unsubscribed".to_string(),
+                                "mailto" => "Unsubscribe email sent".to_string(),
+                                "link" => {
+                                    if let Some(url) = out.url {
+                                        let _ = gloo::utils::window()
+                                            .open_with_url_and_target(&url, "_blank");
+                                    }
+                                    "Opened unsubscribe page".to_string()
+                                }
+                                _ => "No standard unsubscribe".to_string(),
+                            },
+                            Err(_) => "Failed".to_string(),
+                        }
+                    }
+                    Ok(resp) => format!("Failed ({})", resp.status()),
+                    Err(_) => "Failed".to_string(),
+                };
+                queue.dispatch(ReviewMsg::UnsubStatus {
+                    key: bundle_key,
+                    label,
+                });
+            });
+        })
+    };
+
     let total_emails: usize = queue.bundles.iter().map(|b| b.items.len()).sum();
     let front = queue.bundles.first().cloned();
     let front_disabled = front
@@ -2993,6 +3045,31 @@ fn archive_review_panel() -> Html {
                                             <>
                                                 <span class="bundle-sender-name">{s}</span>
                                                 <span class="bundle-sender-count">{format!("{} emails from this sender", bundle.items.len())}</span>
+                                                {match queue.unsub.get(&bundle_key) {
+                                                    Some(status) if status == "..." => html! {
+                                                        <span class="unsub-status">{"Unsubscribing..."}</span>
+                                                    },
+                                                    Some(status) => html! {
+                                                        <span class="unsub-status">{status.clone()}</span>
+                                                    },
+                                                    None => {
+                                                        let unsub = on_unsubscribe.clone();
+                                                        let email_id = bundle.items.first().map(|i| i.email_id);
+                                                        html! {
+                                                            <button
+                                                                class="btn-secondary unsub-btn"
+                                                                disabled={front_disabled || email_id.is_none()}
+                                                                onclick={Callback::from(move |_| {
+                                                                    if let Some(eid) = email_id {
+                                                                        unsub.emit((bundle_key, eid));
+                                                                    }
+                                                                })}
+                                                            >
+                                                                {"Unsubscribe"}
+                                                            </button>
+                                                        }
+                                                    }
+                                                }}
                                             </>
                                         },
                                         None => html! {

--- a/crates/frontend/styles.css
+++ b/crates/frontend/styles.css
@@ -2350,3 +2350,17 @@ main {
     font-size: 12px;
     color: #7f8c8d;
 }
+
+/* Per-sender unsubscribe affordance in the bundle header */
+.unsub-btn {
+    margin-left: auto;
+    font-size: 12px;
+    padding: 4px 12px;
+}
+
+.unsub-status {
+    margin-left: auto;
+    font-size: 12px;
+    font-weight: 600;
+    color: #1e8449;
+}

--- a/crates/shared-types/src/lib.rs
+++ b/crates/shared-types/src/lib.rs
@@ -442,6 +442,18 @@ pub struct PipelineStatsResponse {
     pub stage_counts: Vec<TriageStageCount>,
 }
 
+/// Outcome of an unsubscribe attempt against an email's List-Unsubscribe
+/// header (RFC 2369 / RFC 8058)
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UnsubscribeResponse {
+    /// "one_click" (RFC 8058 POST, done), "mailto" (unsubscribe email sent),
+    /// "link" (page needs a human - url carries it), or "none" (no
+    /// standardized mechanism on this email)
+    pub method: String,
+    /// Set when method == "link": open this in a browser
+    pub url: Option<String>,
+}
+
 /// Query parameters for listing emails
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct EmailListQuery {
@@ -1169,6 +1181,21 @@ mod serde_roundtrip_tests {
         let parsed = roundtrip(&value);
         assert_eq!(parsed.todo_title, value.todo_title);
         assert_eq!(parsed.priority, value.priority);
+    }
+
+    #[test]
+    fn unsubscribe_response_roundtrips() {
+        let value = UnsubscribeResponse {
+            method: "one_click".to_string(),
+            url: None,
+        };
+        let parsed = roundtrip(&value);
+        assert_eq!(parsed, value);
+        let value = UnsubscribeResponse {
+            method: "link".to_string(),
+            url: Some("https://example.com/unsub".to_string()),
+        };
+        assert_eq!(roundtrip(&value), value);
     }
 
     #[test]


### PR DESCRIPTION
Each sender bundle in the Review tab gains an **Unsubscribe** button. The backend reads the `List-Unsubscribe`/`List-Unsubscribe-Post` headers live from Gmail (metadata-only fetch, so it works for the entire backlog with no schema change) and acts in preference order:

1. **RFC 8058 one-click**: HTTPS POST with the fixed `List-Unsubscribe=One-Click` body — the standard built for exactly this automation. Guarded against SSRF: https-only, named public host, no userinfo/port tricks (unit-tested).
2. **mailto**: sends the unsubscribe email from the account the mail landed in, honoring a `?subject=` if the header carries one.
3. **Plain HTTPS link**: returned to the frontend, which opens it in a new tab — pages that need a human get a human.
4. Neither → "No standard unsubscribe" reported inline.

The button reports its outcome in place (Unsubscribed / email sent / page opened / none), so unsubscribe-then-archive becomes two clicks on the same card.